### PR TITLE
feat:extract company slug from work email

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "mongoose": "^8.14.1",
     "morgan": "^1.10.0",
     "nodemailer": "^7.0.3",
+    "psl": "^1.15.0",
     "supertest": "^7.1.0",
     "winston": "^3.17.0",
     "yarn": "^1.22.22"

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -5,6 +5,7 @@ import UserModel from '../models/user';
 import ValidationException from '../exceptions/validationException';
 import { isValidEmail, isValidPassword } from '../utils';
 import config from '../config';
+import { extractCompanySlug } from '../middleware/extractCompanySlugFromEmail';
 
 export const register = async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -28,6 +29,9 @@ export const register = async (req: Request, res: Response, next: NextFunction) 
       locale?: string;
     } = req.body;
 
+    // get company slug
+    const companySlug = extractCompanySlug(email);
+
     const { refreshToken } = await authService.registerUser({
       firstname,
       lastname,
@@ -36,6 +40,7 @@ export const register = async (req: Request, res: Response, next: NextFunction) 
       email,
       avatarUrl,
       locale,
+      companySlug,
     });
 
     // request

--- a/src/handlers/v1/authRoute.ts
+++ b/src/handlers/v1/authRoute.ts
@@ -2,7 +2,6 @@ import { Request, Response, NextFunction, Router } from 'express';
 import * as authController from '../../controllers/authController';
 import { validateBody } from '../../middleware/validationMiddleware';
 import authValidationSchema from '../../validations/userAuthValidation';
-
 const router = Router();
 
 // Helper function to handle async routes
@@ -17,7 +16,7 @@ const asyncHandler =
   };
 
 router.post(
-  '/register',
+  '/register/admin',
   validateBody(authValidationSchema.register),
   asyncHandler(authController.register),
 );

--- a/src/handlers/v1/index.ts
+++ b/src/handlers/v1/index.ts
@@ -15,7 +15,7 @@ v1Router.get('/health', (req: Request, res: Response) => {
 });
 
 // Protected test route handler
-interface IAuthUser {
+interface AuthUser {
   _id: string;
   email: string;
   role: string;
@@ -24,7 +24,7 @@ interface IAuthUser {
 
 declare module 'express-serve-static-core' {
   interface Request {
-    user?: IAuthUser;
+    user?: AuthUser;
   }
 }
 

--- a/src/lib/jwtUtils.ts
+++ b/src/lib/jwtUtils.ts
@@ -1,5 +1,7 @@
 import jwt, { Secret, JwtPayload, SignOptions } from 'jsonwebtoken';
 import { config } from '../config';
+import UnauthorizedException from '../exceptions/unauthorizedException';
+import logger from '../utils/logger';
 
 // Default values in case configuration isn't set
 const DEFAULT_JWT_SECRET = 'your-secret-key-should-be-in-env-file';
@@ -59,11 +61,12 @@ export const jwtUtils = {
       const decoded = jwt.verify(token, secret) as ResetTokenPayload;
 
       if (decoded.purpose !== 'password-reset') {
-        throw new Error('Invalid token purpose');
+        throw new UnauthorizedException('Invalid token purpose');
       }
 
       return decoded;
     } catch (error) {
+      logger.error('Verify Password failed');
       throw error;
     }
   },
@@ -87,7 +90,7 @@ export const jwtUtils = {
       const secret: Secret = config.jwt?.secret || DEFAULT_JWT_SECRET;
       return jwt.verify(token, secret) as TokenPayload;
     } catch (error) {
-      throw error;
+      throw new UnauthorizedException('Verify Access Token failed', { payload: error });
     }
   },
 
@@ -99,7 +102,7 @@ export const jwtUtils = {
       const secret: Secret = config.jwt?.refreshSecret || DEFAULT_JWT_SECRET;
       return jwt.verify(token, secret) as TokenPayload;
     } catch (error) {
-      throw error;
+      throw new UnauthorizedException('Verify Fresh Token failed', { payload: error });
     }
   },
 };

--- a/src/middleware/extractCompanySlugFromEmail.ts
+++ b/src/middleware/extractCompanySlugFromEmail.ts
@@ -1,0 +1,43 @@
+import { parse } from 'psl';
+import ValidationException from '../exceptions/validationException';
+
+const blockedDomains = [
+  'gmail.com',
+  'yahoo.com',
+  'hotmail.com',
+  'outlook.com',
+  'icloud.com',
+  'aol.com',
+  'msn.com',
+  'live.com',
+  'mail.com',
+  'protonmail.com',
+];
+
+export function extractCompanySlug(email: string): string {
+  const domain = email.split('@')[1]?.toLowerCase();
+  if (!domain) {
+    throw new ValidationException('Please provide a valid email address');
+  }
+
+  if (blockedDomains.includes(domain)) {
+    // reject public email
+    throw new ValidationException('Public email not allowed');
+  }
+
+  // Determine the structure of a domain name, identify top-level domains, subdomains, primary domains, etc
+  const parsed = parse(domain);
+  if (
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    'domain' in parsed &&
+    typeof parsed.domain === 'string'
+  ) {
+    const slug = parsed.domain.split('.')[0];
+    if (slug) {
+      return slug;
+    }
+  }
+
+  throw new ValidationException('Please provide a valid email address');
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,17 +2,16 @@ import winston from 'winston';
 import path from 'path';
 import config from '../config';
 
-// createLogger(__filename);
 export const createLogger = (filename?: string): winston.Logger => {
   const logger = winston.createLogger({
     level: config.logLevel,
     defaultMeta: {
-      filename: filename ? path.basename(filename) : undefined,
+      filename: filename ? path.basename(String(filename)) : undefined,
     },
     format: winston.format.combine(
       winston.format.timestamp(),
       winston.format.printf(({ timestamp, filename, level, message, payload }) => {
-        const fileInfo = filename ? `[${filename}]` : '';
+        const fileInfo = typeof filename === 'string' ? `[${filename}]` : '';
         const payloadInfo = payload ? `\n${JSON.stringify(payload, null, 2)}` : '';
         return `[${timestamp}][${level}] ${fileInfo}: ${message}${payloadInfo}`;
       }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3743,6 +3743,13 @@ proxy-from-env@^1.1.0:
   resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
+psl@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.15.0.tgz#bdace31896f1d97cec6a79e8224898ce93d974c6"
+  integrity sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==
+  dependencies:
+    punycode "^2.3.1"
+
 pstree.remy@^1.1.8:
   version "1.1.8"
   resolved "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz"


### PR DESCRIPTION
Feature/user register.
Extract company slug from work email.
Notes:

email cannot be null or public email like {
'gmail.com',
'yahoo.com',
'hotmail.com',
'outlook.com',
'icloud.com',
'aol.com',
'msn.com',
'live.com',
'mail.com',
'protonmail.com',
}
at lease have one domain to extract(not like xxx@com ).
Multi level domain name taking the primary domain name, using the PSL dependence.([xxx@company.ibc.com](mailto:xxx@company.ibc.com): ibc is domain).
When creating a user, company already exists. --> create membership in same time