### PR TITLE
[Fix]mongoose model enum fix and remove redirect url

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -93,8 +93,6 @@ export const ROUTES = {
   REGISTER_USER_ADMIN: ' /v1/auth/register/admin',
 };
 
-
-
 // Mongoose DB type and default value
 // companyPlan
 export const COMPANY_PLANS = {
@@ -102,7 +100,7 @@ export const COMPANY_PLANS = {
   PRO: 'pro',
   ENTERPRISE: 'enterprise',
 } as const;
-export type CompanyPlanType = typeof COMPANY_PLANS[keyof typeof COMPANY_PLANS];
+export type CompanyPlanType = (typeof COMPANY_PLANS)[keyof typeof COMPANY_PLANS];
 export const COMPANY_PLAN_LIST = Object.values(COMPANY_PLANS);
 export const DEFAULT_COMPANY_PLAN = COMPANY_PLANS.FREE;
 // locales
@@ -110,7 +108,7 @@ export const LOCALES = {
   EN_US: 'en-US',
   ZH_CN: 'zh-CN',
 } as const;
-export type LocaleType = typeof LOCALES[keyof typeof LOCALES];
+export type LocaleType = (typeof LOCALES)[keyof typeof LOCALES];
 export const LOCALE_LIST = Object.values(LOCALES);
 export const DEFAULT_LOCALE = LOCALES.EN_US;
 // all timezone
@@ -123,14 +121,14 @@ export const ROLE = {
   STUDENT: 'student',
 } as const;
 export type RoleType = (typeof ROLE)[keyof typeof ROLE];
-export const roleList = Object.values(ROLE);// value:['admin', 'instructor', 'student']
+export const roleList = Object.values(ROLE); // value:['admin', 'instructor', 'student']
 // membership status
 export const MEMBERSHIP_STATUS = {
   ACTIVE: 'active',
   INVITED: 'invited',
   DISABLED: 'disabled',
 } as const;
-export type MembershipStatusType = typeof MEMBERSHIP_STATUS[keyof typeof MEMBERSHIP_STATUS];
+export type MembershipStatusType = (typeof MEMBERSHIP_STATUS)[keyof typeof MEMBERSHIP_STATUS];
 export const DEFAULT_MEMBERSHIP_STATUS = MEMBERSHIP_STATUS.ACTIVE;
 
 export default config;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -86,30 +86,51 @@ export const config: Config = {
   },
 };
 
-// Role object
-export const ROLE = {
-  ADMIN: 'admin',
-  INSTRUCTOR: 'instructor',
-  STUDENT: 'student',
-} as const;
-// type: 'admin' | 'instructor' | 'student'
-export type RoleType = (typeof ROLE)[keyof typeof ROLE];
-// value:['admin', 'instructor', 'student']
-export const roleList = Object.values(ROLE);
-
 // Route api
 export const ROUTES = {
   LOGIN_USER: '/v1/auth/login',
   REGISTER_COMPANY: '/v1/companies/register',
   REGISTER_USER_ADMIN: ' /v1/auth/register/admin',
 };
-export const COMPANY_PLANS = ['free', 'pro', 'enterprise'] as const; // type
-export type CompanyPlan = (typeof COMPANY_PLANS)[number]; // ['free', 'pro', 'enterprise']
 
+
+
+// Mongoose DB type and default value
+// companyPlan
+export const COMPANY_PLANS = {
+  FREE: 'free',
+  PRO: 'pro',
+  ENTERPRISE: 'enterprise',
+} as const;
+export type CompanyPlanType = typeof COMPANY_PLANS[keyof typeof COMPANY_PLANS];
+export const COMPANY_PLAN_LIST = Object.values(COMPANY_PLANS);
+export const DEFAULT_COMPANY_PLAN = COMPANY_PLANS.FREE;
 // locales
-export const LOCALES = ['en-US', 'zh-CN'] as const;
-export const DEFAULT_LOCALE = LOCALES[0];
+export const LOCALES = {
+  EN_US: 'en-US',
+  ZH_CN: 'zh-CN',
+} as const;
+export type LocaleType = typeof LOCALES[keyof typeof LOCALES];
+export const LOCALE_LIST = Object.values(LOCALES);
+export const DEFAULT_LOCALE = LOCALES.EN_US;
 // all timezone
 export const TIMEZONES: string[] = moment.tz.names();
+export const DEFAULT_TIMEZONE = TIMEZONES[0];
+// Membership Role
+export const ROLE = {
+  ADMIN: 'admin',
+  INSTRUCTOR: 'instructor',
+  STUDENT: 'student',
+} as const;
+export type RoleType = (typeof ROLE)[keyof typeof ROLE];
+export const roleList = Object.values(ROLE);// value:['admin', 'instructor', 'student']
+// membership status
+export const MEMBERSHIP_STATUS = {
+  ACTIVE: 'active',
+  INVITED: 'invited',
+  DISABLED: 'disabled',
+} as const;
+export type MembershipStatusType = typeof MEMBERSHIP_STATUS[keyof typeof MEMBERSHIP_STATUS];
+export const DEFAULT_MEMBERSHIP_STATUS = MEMBERSHIP_STATUS.ACTIVE;
 
 export default config;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -108,6 +108,7 @@ export type CompanyPlan = (typeof COMPANY_PLANS)[number]; // ['free', 'pro', 'en
 
 // locales
 export const LOCALES = ['en-US', 'zh-CN'] as const;
+export const DEFAULT_LOCALE = LOCALES[0];
 // all timezone
 export const TIMEZONES: string[] = moment.tz.names();
 

--- a/src/controllers/auth/loginController.ts
+++ b/src/controllers/auth/loginController.ts
@@ -5,14 +5,13 @@ export const adminLogin = async (req: Request, res: Response) => {
   // get data from request body
   const { email, password }: { email: string; password: string } = req.body;
   // call user service to do DB operation
-  const { refreshToken, accessToken, username, role } = await loginService.adminLogin({
+  const { refreshToken, accessToken } = await loginService.adminLogin({
     email,
     password,
   });
 
   res.json({
     success: true,
-    redirect: '',
-    data: { refreshToken, accessToken, username, role },
+    data: { refreshToken, accessToken },
   });
 };

--- a/src/controllers/auth/registerController.ts
+++ b/src/controllers/auth/registerController.ts
@@ -1,6 +1,7 @@
 // authentication, authorization
 import { Request, Response } from 'express';
 import { registerService } from '../../services/auth/registerService';
+import { LocaleType } from 'src/config';
 export interface RegistUserInput {
   firstname: string;
   lastname: string;
@@ -8,7 +9,7 @@ export interface RegistUserInput {
   password: string;
   email: string;
   avatarUrl?: string;
-  locale?: string;
+  locale?: LocaleType;
   verifyCode?: string;
 }
 

--- a/src/controllers/companyController.ts
+++ b/src/controllers/companyController.ts
@@ -54,13 +54,11 @@ export const companyController = {
       user: newUser.id,
       company: newCompany.id,
       role: ROLE.ADMIN,
-      status: true,
     });
 
     clearPendingUserData();
     return res.status(201).json({
       message: 'User, Company and Membership created successfully',
-      redirect: ROUTES.LOGIN_USER,
       data: {
         user: newUser._id,
         company: newCompany._id,

--- a/src/controllers/companyController.ts
+++ b/src/controllers/companyController.ts
@@ -6,7 +6,7 @@ import { userService } from '../services/userService';
 import { companyService } from '../services/companyService';
 import { Types } from 'mongoose';
 import { membershipService } from '../services/membershipService';
-import { ROLE, ROUTES } from '../config';
+import { ROLE } from '../config';
 import { clearPendingUserData, getPendingUserData } from '../utils/storagePendingUser';
 import { checkVerificationCode } from '../services/auth/registerService';
 import { RegistUserInput } from './auth/registerController';

--- a/src/middleware/error/errorHandler.ts
+++ b/src/middleware/error/errorHandler.ts
@@ -8,6 +8,7 @@ const errorHandler: ErrorRequestHandler = (
   err: Error,
   req: Request,
   res: Response,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   next: NextFunction,
 ) => {
   // If the response header has already been sent, skip the subsequent processing directly

--- a/src/middleware/validation/adminRegistrationPreCheck.ts
+++ b/src/middleware/validation/adminRegistrationPreCheck.ts
@@ -1,5 +1,4 @@
 import { Request, Response, NextFunction } from 'express';
-import { ROUTES } from '../../config';
 import { extractCompanySlug } from '../../utils/extractCompanySlugFromEmail';
 import AppException from '../../exceptions/appException';
 import { HttpStatusCode } from 'axios';

--- a/src/middleware/validation/adminRegistrationPreCheck.ts
+++ b/src/middleware/validation/adminRegistrationPreCheck.ts
@@ -27,7 +27,6 @@ export const validateRegistration = async (req: Request, res: Response, next: Ne
 
     res.status(302).json({
       message: 'The company does not exist',
-      redirect: ROUTES.REGISTER_COMPANY,
       user: getSafePendingUserData(),
     });
     return;
@@ -39,7 +38,6 @@ export const validateRegistration = async (req: Request, res: Response, next: Ne
     // user and company all exist
     res.status(302).json({
       message: 'User already exist, please login',
-      redirect: ROUTES.LOGIN_USER,
     });
     return;
   }

--- a/src/models/company.ts
+++ b/src/models/company.ts
@@ -1,15 +1,15 @@
 import mongoose, { Document, Schema } from 'mongoose';
-import { COMPANY_PLANS, CompanyPlan, TIMEZONES, LOCALES } from '../config';
+import { COMPANY_PLANS, TIMEZONES, LOCALES, DEFAULT_LOCALE, DEFAULT_COMPANY_PLAN, CompanyPlanType, LocaleType } from '../config';
 import MembershipModel from './membership';
 
 export interface Company extends Document {
   companyName: string;
   slug: string;
-  plan: CompanyPlan;
+  plan: CompanyPlanType;
   owner: mongoose.Types.ObjectId;
   settings?: {
     timezone?: string;
-    locale?: string;
+    locale?: LocaleType;
     logoUrl?: string;
     primaryColor?: string;
   };
@@ -33,7 +33,7 @@ const companySchema = new Schema(
       type: String,
       enum: COMPANY_PLANS,
       required: true,
-      default: 'free',
+      default: DEFAULT_COMPANY_PLAN,
     },
     owner: {
       type: mongoose.Schema.Types.ObjectId,
@@ -45,12 +45,12 @@ const companySchema = new Schema(
       timezone: {
         type: String,
         enum: TIMEZONES,
-        default: 'UTC',
+        default: TIMEZONES[0],
       },
       locale: {
         type: String,
         enum: LOCALES,
-        default: 'en-US',
+        default: DEFAULT_LOCALE,
       },
       logoUrl: {
         type: String,
@@ -86,7 +86,7 @@ const companySchema = new Schema(
 
 // When deleting a company, delete the relevant membership
 companySchema.pre('deleteOne', { document: true, query: false }, async function (next) {
-  await MembershipModel.deleteMany({ user: this._id });
+  await MembershipModel.deleteMany({ company: this._id });
   next();
 });
 

--- a/src/models/company.ts
+++ b/src/models/company.ts
@@ -1,5 +1,13 @@
 import mongoose, { Document, Schema } from 'mongoose';
-import { COMPANY_PLANS, TIMEZONES, LOCALES, DEFAULT_LOCALE, DEFAULT_COMPANY_PLAN, CompanyPlanType, LocaleType } from '../config';
+import {
+  COMPANY_PLANS,
+  TIMEZONES,
+  LOCALES,
+  DEFAULT_LOCALE,
+  DEFAULT_COMPANY_PLAN,
+  CompanyPlanType,
+  LocaleType,
+} from '../config';
 import MembershipModel from './membership';
 
 export interface Company extends Document {

--- a/src/models/membership.ts
+++ b/src/models/membership.ts
@@ -1,11 +1,11 @@
 import mongoose, { Document, Schema } from 'mongoose';
-import { RoleType, roleList } from '../config';
+import { MEMBERSHIP_STATUS, MembershipStatusType, RoleType, roleList } from '../config';
 
 export interface Membership extends Document {
   company: mongoose.Types.ObjectId;
   user: mongoose.Types.ObjectId;
   role: RoleType;
-  active: boolean;
+  status: MembershipStatusType;
 }
 
 const membershipSchema = new Schema(
@@ -27,9 +27,10 @@ const membershipSchema = new Schema(
       enum: roleList,
       required: true,
     },
-    active: {
-      type: Boolean,
-      default: true,
+    status: {
+      type: String,
+      enum: MEMBERSHIP_STATUS,
+      default: MEMBERSHIP_STATUS.ACTIVE,
     },
   },
   // timestamp auto createAt and updateAt

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -5,6 +5,7 @@ import MembershipModel from './membership';
 import { jwtUtils } from '../lib/jwtUtils';
 import AppException from '../exceptions/appException';
 import { HttpStatusCode } from 'axios';
+import { DEFAULT_LOCALE, LOCALES } from '../config';
 
 export interface User extends Document {
   firstname: string;
@@ -85,8 +86,8 @@ const userSchema: Schema<User> = new Schema(
     locale: {
       type: String,
       required: false,
-      enum: ['en', 'zh'],
-      default: 'en',
+      enum: LOCALES,
+      default: DEFAULT_LOCALE,
     },
     refreshToken: {
       type: String,

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -5,7 +5,7 @@ import MembershipModel from './membership';
 import { jwtUtils } from '../lib/jwtUtils';
 import AppException from '../exceptions/appException';
 import { HttpStatusCode } from 'axios';
-import { DEFAULT_LOCALE, LOCALES } from '../config';
+import { DEFAULT_LOCALE, LOCALES, LocaleType } from '../config';
 
 export interface User extends Document {
   firstname: string;
@@ -14,7 +14,7 @@ export interface User extends Document {
   password: string;
   email: string;
   avatarUrl: string;
-  locale: string;
+  locale: LocaleType;
   createdAt: Date;
   active: boolean;
   refreshToken?: string;

--- a/src/services/auth/loginService.ts
+++ b/src/services/auth/loginService.ts
@@ -1,20 +1,17 @@
 import UserModel from '../../models/user';
 import AppException from '../../exceptions/appException';
 import { HttpStatusCode } from 'axios';
-import { ROLE, ROUTES } from '../../config';
-import { extractCompanySlug } from '../../utils/extractCompanySlugFromEmail';
-import CompanyModel from '../../models/company';
-import { getSafePendingUserData, setPendingUserData } from '../../utils/storagePendingUser';
+import { ROUTES } from '../../config';
 
 export const loginService = {
   adminLogin: async ({ email, password }: { email: string; password: string }) => {
     // check user exist
     const user = await UserModel.findOne({ email });
     if (!user) {
-      throw new AppException(HttpStatusCode.NotFound, 'Invalid credentials.', {
-        payload: { redirectTo: ROUTES.REGISTER_USER_ADMIN },
-      });
-    } // verify password
+      throw new AppException(HttpStatusCode.NotFound, 'Invalid credentials.'
+      );
+    }
+    // verify password
     const isValidPassword = await user.validatePassword(password);
     if (!isValidPassword) {
       throw new AppException(HttpStatusCode.Unauthorized, 'Invalid credentials');
@@ -22,23 +19,12 @@ export const loginService = {
 
     // generate token
     const { refreshToken, accessToken } = await user.generateTokens();
-    // get company
-    const companySlug = await extractCompanySlug(email);
-    const company = await CompanyModel.findOne({ slug: companySlug });
-    if (!company) {
-      // company not exist
-      setPendingUserData(user.toObject());
-
-      throw new AppException(HttpStatusCode.NotFound, 'Invalid credentials', {
-        payload: { redirectTo: ROUTES.REGISTER_COMPANY, user: getSafePendingUserData() },
-      });
-    }
 
     // save refreshToken
     user.refreshToken = refreshToken;
     await user.save();
     // get user all roles
 
-    return { refreshToken, accessToken, username: user.username, role: ROLE.ADMIN };
+    return { refreshToken, accessToken };
   },
 };

--- a/src/services/auth/loginService.ts
+++ b/src/services/auth/loginService.ts
@@ -1,15 +1,13 @@
 import UserModel from '../../models/user';
 import AppException from '../../exceptions/appException';
 import { HttpStatusCode } from 'axios';
-import { ROUTES } from '../../config';
 
 export const loginService = {
   adminLogin: async ({ email, password }: { email: string; password: string }) => {
     // check user exist
     const user = await UserModel.findOne({ email });
     if (!user) {
-      throw new AppException(HttpStatusCode.NotFound, 'Invalid credentials.'
-      );
+      throw new AppException(HttpStatusCode.NotFound, 'Invalid credentials.');
     }
     // verify password
     const isValidPassword = await user.validatePassword(password);

--- a/src/services/companyService.ts
+++ b/src/services/companyService.ts
@@ -2,16 +2,17 @@ import mongoose from 'mongoose';
 import CompanyModel, { Company } from '../models/company';
 import AppException from '../exceptions/appException';
 import { HttpStatusCode } from 'axios';
-import { CompanyPlan } from '../config';
+import { CompanyPlanType, LocaleType } from '../config';
+import UserModel from '../models/user';
 
 export interface CompanyCreateInput {
   companyName: string;
   slug: string;
-  plan: CompanyPlan;
+  plan: CompanyPlanType;
   owner: mongoose.Types.ObjectId;
   settings?: {
     timezone?: string;
-    locale?: string;
+    locale?: LocaleType;
     logoUrl?: string;
     primaryColor?: string;
   };
@@ -23,6 +24,10 @@ export const companyService = {
     const existCompany = await CompanyModel.findOne({ slug: companyInput.slug });
     if (existCompany) {
       throw new AppException(HttpStatusCode.Conflict, 'Company already exists');
+    }
+    const existOwner = await UserModel.exists({ _id: companyInput.owner });
+    if (!existOwner) {
+      throw new AppException(HttpStatusCode.BadRequest, 'Owner user not found');
     }
     const ownedCompany = await CompanyModel.findOne({ owner: companyInput.owner });
     if (ownedCompany) {

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -2,6 +2,7 @@ import { HttpStatusCode } from 'axios';
 import UserModel, { User } from '../models/user';
 import AppException from '../exceptions/appException';
 import { Types } from 'mongoose';
+import { LocaleType } from 'src/config';
 
 export interface UserCreateInput {
   firstname: string;
@@ -10,7 +11,7 @@ export interface UserCreateInput {
   password: string;
   email: string;
   avatarUrl?: string;
-  locale?: string;
+  locale?: LocaleType;
 }
 
 export const userService = {
@@ -23,7 +24,7 @@ export const userService = {
       throw new AppException(HttpStatusCode.Conflict, 'User email or username already exist');
     }
 
-    const user = await UserModel.create(userInput);
+    const user = new UserModel(userInput);
     await user.hashPassword();
     await user.save();
 
@@ -37,7 +38,7 @@ export const userService = {
     }
     const user = await UserModel.findById(userId);
     if (!user) {
-      throw new AppException(HttpStatusCode.InternalServerError, 'User not found');
+      throw new AppException(HttpStatusCode.NotFound, 'User not found');
     }
 
     return user;

--- a/src/validations/companyValidaton.ts
+++ b/src/validations/companyValidaton.ts
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { COMPANY_PLANS, LOCALES, TIMEZONES } from '../config';
+import { COMPANY_PLAN_LIST, COMPANY_PLANS, DEFAULT_COMPANY_PLAN, DEFAULT_LOCALE, DEFAULT_TIMEZONE, LOCALE_LIST, LOCALES, TIMEZONES } from '../config';
 
 // logoUrl
 const logoUrlRegex = /^https?:\/\/.*\.(jpeg|jpg|png|gif|webp|svg)$/i;
@@ -13,8 +13,8 @@ export const companyValidationSchema = Joi.object({
   slug: Joi.string().trim().lowercase().optional(),
 
   plan: Joi.string()
-    .valid(...COMPANY_PLANS)
-    .default('free')
+    .valid(...COMPANY_PLAN_LIST)
+    .default(DEFAULT_COMPANY_PLAN)
     .required(),
 
   owner: Joi.string().length(24).hex().optional(),
@@ -22,15 +22,15 @@ export const companyValidationSchema = Joi.object({
   settings: Joi.object({
     timezone: Joi.string()
       .valid(...TIMEZONES)
-      .default('UTC')
+      .default(DEFAULT_TIMEZONE)
       .messages({
-        'any.only': `timezone invalid, Eg:${TIMEZONES[0]}`,
+        'any.only': `timezone invalid, Eg:${DEFAULT_TIMEZONE}`,
       }),
     locale: Joi.string()
-      .valid(...LOCALES)
-      .default('en-US')
+      .valid(...LOCALE_LIST)
+      .default(DEFAULT_LOCALE)
       .messages({
-        'any.only': `Locale must be either: ${LOCALES.join(', ')}`,
+        'any.only': `Locale must be either: ${LOCALE_LIST.join(',')}`,
       }),
     logoUrl: Joi.string()
       .allow('')

--- a/src/validations/companyValidaton.ts
+++ b/src/validations/companyValidaton.ts
@@ -20,6 +20,8 @@ export const companyValidationSchema = Joi.object({
   slug: Joi.string().trim().lowercase().optional(),
 
   plan: Joi.string()
+    .trim()
+    .lowercase()
     .valid(...COMPANY_PLAN_LIST)
     .default(DEFAULT_COMPANY_PLAN)
     .required(),
@@ -29,13 +31,15 @@ export const companyValidationSchema = Joi.object({
   settings: Joi.object({
     timezone: Joi.string()
       .valid(...TIMEZONES)
+      .trim()
       .default(DEFAULT_TIMEZONE)
       .messages({
-        'any.only': `timezone invalid, Eg:${DEFAULT_TIMEZONE}`,
+        'any.only': `timezone invalid, Eg:${TIMEZONES.join(',')}`,
       }),
     locale: Joi.string()
       .valid(...LOCALE_LIST)
       .default(DEFAULT_LOCALE)
+      .trim()
       .messages({
         'any.only': `Locale must be either: ${LOCALE_LIST.join(',')}`,
       }),

--- a/src/validations/companyValidaton.ts
+++ b/src/validations/companyValidaton.ts
@@ -1,5 +1,12 @@
 import Joi from 'joi';
-import { COMPANY_PLAN_LIST, COMPANY_PLANS, DEFAULT_COMPANY_PLAN, DEFAULT_LOCALE, DEFAULT_TIMEZONE, LOCALE_LIST, LOCALES, TIMEZONES } from '../config';
+import {
+  COMPANY_PLAN_LIST,
+  DEFAULT_COMPANY_PLAN,
+  DEFAULT_LOCALE,
+  DEFAULT_TIMEZONE,
+  LOCALE_LIST,
+  TIMEZONES,
+} from '../config';
 
 // logoUrl
 const logoUrlRegex = /^https?:\/\/.*\.(jpeg|jpg|png|gif|webp|svg)$/i;

--- a/src/validations/userAuthValidation.ts
+++ b/src/validations/userAuthValidation.ts
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { DEFAULT_LOCALE, LOCALE_LIST, LOCALES } from '../config';
+import { DEFAULT_LOCALE, LOCALE_LIST } from '../config';
 
 const baseAuthSchema = Joi.object({
   email: Joi.string()

--- a/src/validations/userAuthValidation.ts
+++ b/src/validations/userAuthValidation.ts
@@ -64,6 +64,7 @@ const registerSchema = baseAuthSchema.keys({
   locale: Joi.string()
     .valid(...LOCALE_LIST)
     .default(DEFAULT_LOCALE)
+    .trim()
     .messages({
       'any.only': `Locale must be either: ${LOCALE_LIST.join(', ')}`,
     }),

--- a/src/validations/userAuthValidation.ts
+++ b/src/validations/userAuthValidation.ts
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { LOCALES } from '../config';
+import { DEFAULT_LOCALE, LOCALE_LIST, LOCALES } from '../config';
 
 const baseAuthSchema = Joi.object({
   email: Joi.string()
@@ -62,10 +62,10 @@ const registerSchema = baseAuthSchema.keys({
     }),
 
   locale: Joi.string()
-    .valid(...LOCALES)
-    .default('en')
+    .valid(...LOCALE_LIST)
+    .default(DEFAULT_LOCALE)
     .messages({
-      'any.only': `Locale must be either: ${LOCALES.join(', ')}`,
+      'any.only': `Locale must be either: ${LOCALE_LIST.join(', ')}`,
     }),
 
   verifyCode: Joi.string().required().messages({


### PR DESCRIPTION
📌 Background
Inconsistencies in enum definitions (e.g., locale, timezone, role, company plan) across different files were causing validation errors and logic mismatches. Additionally, the backend no longer needs to return frontend-related redirect URLs, so these have been removed to simplify API responses.
🔧 Main Changes
Unified enum values such as LOCALE_LIST, TIMEZONES, ROLES, and COMPANY_PLAN_LIST into shared constants used across Mongoose models, Joi validation, and service logic.
Defined default values (e.g., DEFAULT_LOCALE, DEFAULT_TIMEZONE) in constants and reused them consistently.
Updated Joi schemas to strictly validate against the shared enum constants.
Refactored relevant service logic for consistency and reusability.
Removed unused redirectUrl fields from API responses.
Removed the role field from login response as part of a future permissions redesign.
📍 Impact Scope
All files related to locale, timezone, role, and company plan enums across models, validators, and services.
All response structures previously containing redirectUrl.
Login API response structure (removed role field).
✅ How to Test
Send a POST /api/v1/auth/register/admin request with "locale": "en-US" — should pass validation.
Send a POST /api/v1/company/register request with the following payload — should pass validation:
"settings": {
  "timezone": "Africa/Abidjan",
  "locale": "en-US"
}
Submitting invalid enum values (e.g., incorrect timezone or locale) should trigger Joi validation errors.
API responses should no longer contain redirectUrl or the role field in login responses.