### PR TITLE
[Chore]: LA-import-sort-auto

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,6 +65,7 @@ module.exports = [
       '@typescript-eslint': typescriptPlugin,
       prettier: prettierPlugin,
       local: localRulesPlugin,
+      'simple-import-sort': require('eslint-plugin-simple-import-sort'),
     },
     rules: {
       // TypeScript recommended rules
@@ -95,6 +96,8 @@ module.exports = [
       'no-console': 'error',
       'no-debugger': 'error',
       'local/no-dev-notes': 'error',
+      'simple-import-sort/imports': 'warn',
+      'simple-import-sort/exports': 'warn',
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/loaders/server.js",
-    "dev": "nodemon --watch src --ext ts --exec ts-node ./loaders/server.ts",
+    "dev": "nodemon --watch src --ext ts --exec ts-node -r tsconfig-paths/register ./loaders/server.ts",
     "debug": "node --inspect dist/loaders/server.js",
     "lint": "eslint \"{src,loaders,tests}/**/*.ts\" --fix",
     "format": "prettier --write \"{src,tests,loaders}/**/*.ts\"",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "eslint": "^9.27.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.4.1",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "lint-staged": "^16.1.0",
@@ -98,6 +99,7 @@
     "prettier": "^3.5.3",
     "ts-jest": "^29.3.2",
     "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.8.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,10 +27,21 @@
         "rootDir": "./", /* Changed to include the entire project */
         "moduleResolution": "node", /* Specify how TypeScript looks up a file from a given module specifier. */
         "baseUrl": ".", /* Specify the base directory to resolve non-relative module names. */
+        "paths": {
+            "@src/*": [
+                "src/*"
+            ],
+            "@loaders/*": [
+                "loaders/*"
+            ],
+            "@tests/*": [
+                "tests/*"
+            ],
+        },
         // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
         "typeRoots": [
             "./src/types"
-        ],   
+        ],
         // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
         // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
         // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2945,6 +2945,11 @@ eslint-plugin-prettier@^5.4.1:
     prettier-linter-helpers "^1.0.0"
     synckit "^0.11.7"
 
+eslint-plugin-simple-import-sort@^12.1.1:
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz#e64bfdaf91c5b98a298619aa634a9f7aa43b709e"
+  integrity sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==
+
 eslint-scope@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-8.3.0.tgz#10cd3a918ffdd722f5f3f7b5b83db9b23c87340d"
@@ -4385,7 +4390,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
-json5@^2.2.3:
+json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -5844,6 +5849,11 @@ strip-bom@4.0.0, strip-bom@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
   integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
+
 strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
@@ -6050,6 +6060,15 @@ ts-node@^10.9.2:
     make-error "^1.1.1"
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
+
+tsconfig-paths@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz#ef78e19039133446d244beac0fd6a1632e2d107c"
+  integrity sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==
+  dependencies:
+    json5 "^2.2.2"
+    minimist "^1.2.6"
+    strip-bom "^3.0.0"
 
 tslib@^2.1.0:
   version "2.8.1"


### PR DESCRIPTION
Motivation
In order to improve code consistency and maintainability, avoid disorderly import order, and unify team development standards, we now introduce eslint plugin simple import sort to automatically sort and clean up import statements.

Changes
Install eslint plugin simple import port @ ^ 12.1.1
Register plugins and rules in eslint.config.js:
simple-import-sort/imports
simple-import-sort/exports
Configure path aliases for tsconfig. json (such as @ src/*, @ loaders/*, etc.) to match import sorting
Add tsconfig paths dependency to support runtime parsing of TypeScript path aliases

Tests
Execute yarn lint and observe if the import statement automatically sorts according to the rules
Manually adjust several import orders and run yarn lint -- fix to verify if the plugin can automatically fix them

Checklist
Installed the plugin and configured it correctly in eslint.config.js
Added sorting rules for import and export
Add and test path alias resolution (tsconfig+tsconfig paths)
