### PR TITLE
Chore / LA naming conventions

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -95,6 +95,27 @@ module.exports = [
       'no-console': 'error',
       'no-debugger': 'error',
       'local/no-dev-notes': 'error',
+      '@typescript-eslint/naming-convention': [
+        'error',
+        //（type/interface/class）use PascalCase
+        {
+          selector: 'typeLike',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'interface',
+          format: ['PascalCase'],
+          custom: {
+            regex: '^I[A-Z]',
+            match: false,
+          },
+        },
+        // use camelCase for variable
+        {
+          selector: 'variable',
+          format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
+        },
+      ],
     },
   },
 ];


### PR DESCRIPTION
Motivation
In order to unify the team's code style, enhance readability and maintainability, we have added mandatory naming conventions for Eslint.

Changes
Add the @ typescript eslint/taming conversion rule in ESLint configuration:
TypeLike (type/interface/class, etc.) must use PascalCase
Interface prohibits the use of the I prefix (such as IUser) ❌， User  ✅）
The variable name needs to be camelCase, PascalCase, or UPPER_CSE

Tests
Run yarn lint locally to verify ESLint check is effective
Attempted to submit for incorrect naming, successfully intercepted

Checklist
Add naming conventions and rules
Local testing is correct