### PR TITLE
LUMA7-updateInvitationLink for instructor

### DIFF
--- a/src/utils/invitationLink.ts
+++ b/src/utils/invitationLink.ts
@@ -1,9 +1,10 @@
 import jwt, { Secret, JwtPayload, SignOptions } from 'jsonwebtoken';
 import { config } from '../config';
-import { RoleType, EXPIRES_TIME_CONFIG } from '../config';
+import { RoleType, ROLE, EXPIRES_TIME_CONFIG } from '../config';
 import AppException from '../exceptions/appException';
 import { HttpStatusCode } from 'axios';
 import ResetCodeModel from '../models/resetCode';
+import { extractCompanySlug } from './extractCompanySlugFromEmail';
 
 interface InvitationTokenPayload extends JwtPayload {
   email: string;
@@ -45,7 +46,14 @@ export async function generateInvitationLink(email: string, role: RoleType): Pro
     attempts: 0,
   });
 
-  const signupBaseUrl = 'http://localhost:5173/auth/signup';
+  // currently we fixed the signup URL to localhost for development
+  // In production, this should be replaced with the actual base URL of application
+  let signupBaseUrl = 'http://localhost:5173/auth/signup';
+
+  if (role === ROLE.INSTRUCTOR) {
+    // If the role is INSTRUCTOR, append the teacher path to the signup URL
+    signupBaseUrl = `${signupBaseUrl}/teacher`;
+  }
   return `${signupBaseUrl}?token=${token}`;
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fc33901d-0a5e-43bc-a438-db7d0a75c425)
This pull request updates the `generateInvitationLink` function in `src/utils/invitationLink.ts` to improve URL handling for different user roles and adds a utility function import for potential future use. The most important changes include the introduction of role-specific signup URLs and the addition of a new utility function for extracting company slugs.

### Role-specific signup URL handling:
* Updated the `generateInvitationLink` function to append a `/teacher` path to the signup URL if the user role is `ROLE.INSTRUCTOR`, ensuring role-specific redirection during signup.

### Utility function addition:
* Imported the `extractCompanySlug` utility function from `./extractCompanySlugFromEmail`, though it is not yet used in the current implementation. This prepares the codebase for future enhancements.