### PR TITLE
[fix ][LUMA 9]feat: adapt register verify code for admin leaner and company

### DIFF
--- a/src/controllers/companyController.ts
+++ b/src/controllers/companyController.ts
@@ -5,7 +5,6 @@ import { Types } from 'mongoose';
 import { ROLE } from '../config';
 import AppException from '../exceptions/appException';
 import UserModel, { User } from '../models/user';
-import { checkVerificationCode } from '../services/auth/registerService';
 import { companyService } from '../services/companyService';
 import { membershipService } from '../services/membershipService';
 import { userService } from '../services/userService';
@@ -27,10 +26,8 @@ export const companyController = {
       return res.status(400).json({ message: 'Missing user registration data' });
     }
 
-    // verify code
-    if (pendingUser.verifyValue) {
-      await checkVerificationCode(pendingUser.verifyValue, pendingUser.email);
-    }
+    // company create do not need to check verify code, // because it is created by user registration and verify code is verified in user register
+
     // check company slug
     const slug = await extractCompanySlug(pendingUser.email);
     if (!slug) {

--- a/src/middleware/validation/adminRegistrationPreCheck.ts
+++ b/src/middleware/validation/adminRegistrationPreCheck.ts
@@ -5,11 +5,12 @@ import { RegisterUserInput } from '../../controllers/auth/registerController';
 import AppException from '../../exceptions/appException';
 import CompanyModel from '../../models/company';
 import UserModel from '../../models/user';
+import { checkVerificationCode } from '../../services/auth/registerService';
 import { extractCompanySlug } from '../../utils/extractCompanySlugFromEmail';
 import { getSafePendingUserData, setPendingUserData } from '../../utils/storagePendingUser';
 
 export const validateRegistration = async (req: Request, res: Response, next: NextFunction) => {
-  const { email, username } = req.body;
+  const { email, username, verifyValue } = req.body;
   if (!email) {
     throw new AppException(HttpStatusCode.BadRequest, 'Email is required');
   }
@@ -30,6 +31,9 @@ export const validateRegistration = async (req: Request, res: Response, next: Ne
     });
     return;
   }
+
+  // check verification code, error will be thrown if verification code is not valid
+  await checkVerificationCode(verifyValue, email);
 
   // check company
   const companySlug = await extractCompanySlug(email);

--- a/src/utils/invitationLink.ts
+++ b/src/utils/invitationLink.ts
@@ -1,5 +1,4 @@
 import { HttpStatusCode } from 'axios';
-import { Request } from 'express';
 import jwt, { JwtPayload, Secret, SignOptions } from 'jsonwebtoken';
 
 import { EXPIRES_TIME_CONFIG, ROLE, RoleType } from '../config';


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6614c4e1-5bcc-4ca3-9b9c-8da1c3332378)
![image](https://github.com/user-attachments/assets/da3d9404-9a57-46e4-b340-2bac5faf6544)

### Refactoring of Verification Code Checks:
* Removed verification code checks from the `companyController` as they are now handled during user registration. (`src/controllers/companyController.ts`, [src/controllers/companyController.tsL30-R30](diffhunk://#diff-761aea55ebcb66c8ccfb1e61746aeb94a296cf9cb2bd57c76b090c824eee33bcL30-R30))
* Added verification code checks to the `validateRegistration` middleware for admin registration pre-checks. (`src/middleware/validation/adminRegistrationPreCheck.ts`, [src/middleware/validation/adminRegistrationPreCheck.tsR35-R37](diffhunk://#diff-98a53e629216da6fd499288f094625de369a0fbe9559714326697f881499c084R35-R37))

### Role-Based Logic for User Registration:
* Updated `createUserAndTokens` in `registerService` to include role-based verification logic, ensuring verification codes are only checked for learners. (`src/services/auth/registerService.ts`, [src/services/auth/registerService.tsL14-R18](diffhunk://#diff-649fc21955cdeba571edea310b2971cbd51ea801efd188448debb43520dd436aL14-R18))
* Modified `adminRegister` and `learnerRegister` methods in `registerService` to pass the appropriate role when creating users. (`src/services/auth/registerService.ts`, [[1]](diffhunk://#diff-649fc21955cdeba571edea310b2971cbd51ea801efd188448debb43520dd436aL42-R42) [[2]](diffhunk://#diff-649fc21955cdeba571edea310b2971cbd51ea801efd188448debb43520dd436aL52-R55)

### Cleanup and Dependency Adjustments:
* Removed unused imports and adjusted dependencies in multiple files, including `companyController` and `invitationLink` utilities. (`src/controllers/companyController.ts`, [[1]](diffhunk://#diff-761aea55ebcb66c8ccfb1e61746aeb94a296cf9cb2bd57c76b090c824eee33bcL8); `src/utils/invitationLink.ts`, [[2]](diffhunk://#diff-dc30142641f4a22f41af3a95dea62325c823e5c57dc496d8e79dbb3874905dbbL2)