### PR TITLE
[Bugfix]: LUM-20 password not match

### DIFF
--- a/src/controllers/auth/passwordResetController.ts
+++ b/src/controllers/auth/passwordResetController.ts
@@ -84,7 +84,6 @@ export const verifyResetCode = async (req: Request, res: Response) => {
 
   // Code is valid - update the password
   user.password = newPassword;
-  await user.hashPassword();
 
   // Delete the reset code record
   await resetCode.deleteOne();

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -113,11 +113,6 @@ const userSchema: Schema<User> = new Schema(
   { timestamps: true },
 );
 
-// password: use 'this:' no arrow function
-userSchema.methods.hashPassword = async function (this: User): Promise<void> {
-  this.password = await bcrypt.hash(this.password, 12);
-};
-
 userSchema.methods.validatePassword = async function (
   this: User,
   password: string,

--- a/src/services/invitationService.ts
+++ b/src/services/invitationService.ts
@@ -37,7 +37,7 @@ export class InvitationService {
     const newUsername = await generateRandomUsername();
     const { newUser } = await createUserAndTokens({
       email,
-      password: 'password@1234',
+      password: '123@Password',
       username: newUsername,
       firstName: 'Invited',
       lastName: 'Teacher',

--- a/src/services/invitationService.ts
+++ b/src/services/invitationService.ts
@@ -37,7 +37,7 @@ export class InvitationService {
     const newUsername = await generateRandomUsername();
     const { newUser } = await createUserAndTokens({
       email,
-      password: 'any',
+      password: 'password@1234',
       username: newUsername,
       firstName: 'Invited',
       lastName: 'Teacher',

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -28,7 +28,6 @@ export const userService = {
     }
 
     const user = new UserModel(userInput);
-    await user.hashPassword();
     await user.save();
 
     return user;


### PR DESCRIPTION
## Background
After changing the hash password to pre triggering it automatically, registered users will hash passwords twice, resulting in password mismatch during login.

## Change
1. Remove hash function manually.
2. Change password default value for invitation, Otherwise, when storing passwords in the database, there will be an error message stating that the length is not sufficient.