### PR TITLE
[Bugfix]:LA-86 Error Handler

### DIFF
--- a/src/middleware/error/errorHandler.ts
+++ b/src/middleware/error/errorHandler.ts
@@ -98,6 +98,12 @@ function processError(err: Error, req: Request): ErrorInfo {
 const multerErrorMessages: Record<string, string> = {
   LIMIT_FILE_SIZE: 'File size exceeds 5MB limit',
   LIMIT_UNEXPECTED_FILE: 'Invalid file type',
+  UNEXPECTED_FIELD: 'Unexpected field name in file upload',
+  LIMIT_FILE_COUNT: 'Too many files uploaded',
+  LIMIT_FIELD_KEY: 'Field name too long',
+  LIMIT_FIELD_VALUE: 'Field value too long',
+  LIMIT_FIELD_COUNT: 'Too many fields',
+  LIMIT_PART_COUNT: 'Too many parts',
 } as const;
 
 function getMulterErrorMessage(err: multer.MulterError): string {

--- a/src/middleware/error/errorHandler.ts
+++ b/src/middleware/error/errorHandler.ts
@@ -9,6 +9,7 @@ interface ErrorInfo {
   statusCode: number;
   message: string;
   logTag: string;
+  logMessage?: string;
   logPayload?: Record<string, unknown>;
 }
 
@@ -35,6 +36,7 @@ function processError(err: Error, req: Request): ErrorInfo {
     return {
       statusCode: 401,
       message: 'Token has expired',
+      logMessage: 'Token has expired',
       logTag: 'TokenExpired Error',
     };
   }
@@ -44,6 +46,7 @@ function processError(err: Error, req: Request): ErrorInfo {
     return {
       statusCode: 500,
       message: 'Internal Server Error',
+      logMessage: 'Invalid token',
       logTag: 'JsonWebToken Error',
     };
   }
@@ -59,10 +62,10 @@ function processError(err: Error, req: Request): ErrorInfo {
 
   // File upload error
   if (err instanceof multer.MulterError) {
-    err.message = getMulterErrorMessage(err) ?? err.message;
     return {
       statusCode: 400,
       message: getMulterErrorMessage(err),
+      logMessage: getMulterErrorMessage(err),
       logTag: 'Multer Error',
     };
   }
@@ -105,8 +108,8 @@ function getMulterErrorMessage(err: multer.MulterError): string {
   return multerErrorMessages[err.code] ?? 'File upload failed';
 }
 
-function logError(err: Error, { logTag, logPayload, statusCode }: ErrorInfo): void {
-  logger.error(`[${logTag} ${statusCode}]: ${err.message}`, {
+function logError(err: Error, { logTag, logMessage, logPayload, statusCode }: ErrorInfo): void {
+  logger.error(`[${logTag} ${statusCode}]: ${logMessage ?? err.message}`, {
     ...logPayload,
   });
 }

--- a/src/middleware/error/errorHandler.ts
+++ b/src/middleware/error/errorHandler.ts
@@ -59,6 +59,7 @@ function processError(err: Error, req: Request): ErrorInfo {
 
   // File upload error
   if (err instanceof multer.MulterError) {
+    err.message = getMulterErrorMessage(err) ?? err.message;
     return {
       statusCode: 400,
       message: getMulterErrorMessage(err),
@@ -98,12 +99,6 @@ function processError(err: Error, req: Request): ErrorInfo {
 const multerErrorMessages: Record<string, string> = {
   LIMIT_FILE_SIZE: 'File size exceeds 5MB limit',
   LIMIT_UNEXPECTED_FILE: 'Invalid file type',
-  UNEXPECTED_FIELD: 'Unexpected field name in file upload',
-  LIMIT_FILE_COUNT: 'Too many files uploaded',
-  LIMIT_FIELD_KEY: 'Field name too long',
-  LIMIT_FIELD_VALUE: 'Field value too long',
-  LIMIT_FIELD_COUNT: 'Too many fields',
-  LIMIT_PART_COUNT: 'Too many parts',
 } as const;
 
 function getMulterErrorMessage(err: multer.MulterError): string {

--- a/src/middleware/error/errorHandler.ts
+++ b/src/middleware/error/errorHandler.ts
@@ -1,90 +1,121 @@
+import AppException from '@src/exceptions/appException';
+import logger from '@src/utils/logger';
 import { ErrorRequestHandler, NextFunction, Request, Response } from 'express';
 import Joi from 'joi';
 import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
 import multer from 'multer';
 
-import AppException from '../../exceptions/appException';
-import logger from '../../utils/logger';
+interface ErrorInfo {
+  statusCode: number;
+  message: string;
+  logTag: string;
+  logPayload?: Record<string, unknown>;
+}
 
 const errorHandler: ErrorRequestHandler = (
   err: Error,
   req: Request,
   res: Response,
   next: NextFunction,
-) => {
+): void => {
   // If the response header has already been sent, skip the subsequent processing directly
   if (res.headersSent) {
     logger.error(`[HeadersSent Error]: ${err.message}`);
-    return next(err); //Error passed to express for default handling
+    return next(err);
   }
 
-  // JWT token Error
-  if (err instanceof TokenExpiredError) {
-    logger.error(`[TokenExpired Error]: ${err.message}`);
-    res.status(401).json({
-      success: false,
-      message: 'Token has expired',
-    });
-    return;
-  }
-
-  if (err instanceof JsonWebTokenError) {
-    logger.error(`[JsonWebToken Error]: ${err.message}`);
-    res.status(401).json({
-      success: false,
-      message: 'Invalid token',
-    });
-    return;
-  }
-
-  //Joi Error
-  if (err instanceof Joi.ValidationError) {
-    logger.error(`[Validation Error]: ${err.message}`);
-    res.status(400).json({
-      success: false,
-      message: err.message,
-    });
-    return;
-  }
-
-  //File upload
-  if (err instanceof multer.MulterError) {
-    let message = 'File upload error';
-
-    switch (err.code) {
-      case 'LIMIT_FILE_SIZE':
-        message = 'File size exceeds 5MB limit';
-        break;
-      case 'LIMIT_UNEXPECTED_FILE':
-        message = 'Invalid file type';
-        break;
-    }
-
-    logger.error(`[File upload error]: ${err.message}`);
-    res.status(400).json({ message });
-    return;
-  }
-
-  // Custom error handler
-  if (err instanceof AppException) {
-    logger.error(`[AppException]: ${err.message}`, {
-      statusCode: err.statusCode,
-      stack: err.stack,
-      ...(err.payload ? { payload: err.payload } : {}),
-    });
-
-    res.status(err.statusCode).json({
-      success: false,
-      message: 'Internal Server Error',
-    });
-    return;
-  }
-
-  logger.error(`[Unhandled Error]: ${err.message}`);
-  res.status(500).json({
-    success: false,
-    message: 'Unhandled Error',
-  });
+  const errorInfo = processError(err, req);
+  logError(err, errorInfo);
+  sendErrorResponse(res, errorInfo);
 };
+
+function processError(err: Error, req: Request): ErrorInfo {
+  // Token expired error
+  if (err instanceof TokenExpiredError) {
+    return {
+      statusCode: 401,
+      message: 'Token has expired',
+      logTag: 'TokenExpired Error',
+    };
+  }
+
+  // JWT token error
+  if (err instanceof JsonWebTokenError) {
+    return {
+      statusCode: 500,
+      message: 'Internal Server Error',
+      logTag: 'JsonWebToken Error',
+    };
+  }
+
+  // Data validation error
+  if (err instanceof Joi.ValidationError) {
+    return {
+      statusCode: 400,
+      message: err.message,
+      logTag: 'Validation Error',
+    };
+  }
+
+  // File upload error
+  if (err instanceof multer.MulterError) {
+    return {
+      statusCode: 400,
+      message: getMulterErrorMessage(err),
+      logTag: 'Multer Error',
+    };
+  }
+
+  // Custom application error
+  if (err instanceof AppException) {
+    return {
+      statusCode: err.statusCode,
+      message: err.statusCode === 500 ? 'Internal Server Error' : err.message,
+      logTag: 'AppException',
+      logPayload: {
+        url: req.originalUrl,
+        method: req.method,
+        stack: err.stack,
+        ...err.payload,
+      },
+    };
+  }
+
+  // Unhandled error
+  return {
+    statusCode: 500,
+    message: 'Internal Server Error',
+    logTag: 'Unhandled Error',
+    logPayload: {
+      url: req.originalUrl,
+      method: req.method,
+      stack: err.stack,
+    },
+  };
+}
+
+// Multer error message mapping
+const multerErrorMessages: Record<string, string> = {
+  LIMIT_FILE_SIZE: 'File size exceeds 5MB limit',
+  LIMIT_UNEXPECTED_FILE: 'Invalid file type',
+} as const;
+
+function getMulterErrorMessage(err: multer.MulterError): string {
+  return multerErrorMessages[err.code] ?? 'File upload failed';
+}
+
+function logError(err: Error, { logTag, logPayload }: ErrorInfo): void {
+  logger.error(`[${logTag}]: ${err.message}`, {
+    stack: err.stack,
+    ...logPayload,
+  });
+}
+
+function sendErrorResponse(res: Response, { statusCode, message }: ErrorInfo): void {
+  res.status(statusCode).json({
+    success: false,
+    message,
+  });
+}
 
 export default errorHandler;

--- a/src/middleware/error/errorHandler.ts
+++ b/src/middleware/error/errorHandler.ts
@@ -104,9 +104,8 @@ function getMulterErrorMessage(err: multer.MulterError): string {
   return multerErrorMessages[err.code] ?? 'File upload failed';
 }
 
-function logError(err: Error, { logTag, logPayload }: ErrorInfo): void {
-  logger.error(`[${logTag}]: ${err.message}`, {
-    stack: err.stack,
+function logError(err: Error, { logTag, logPayload, statusCode }: ErrorInfo): void {
+  logger.error(`[${logTag} ${statusCode}]: ${err.message}`, {
     ...logPayload,
   });
 }

--- a/src/middleware/fileUploader.ts
+++ b/src/middleware/fileUploader.ts
@@ -3,8 +3,6 @@ import fs from 'fs';
 import multer from 'multer';
 import path from 'path';
 
-import logger from '../utils/logger';
-
 interface FileUploadOptions {
   folderName: string;
   allowedMimeTypes: string[];
@@ -54,7 +52,6 @@ export function wrapMulterMiddleware(
   return (req: Request, res: Response, next: NextFunction) => {
     multerMiddleware(req, res, err => {
       if (err) {
-        logger.error('File upload error:', err);
         return next(err);
       }
       next();

--- a/src/services/auth/loginService.ts
+++ b/src/services/auth/loginService.ts
@@ -49,7 +49,7 @@ export const loginService = {
     }
     const matchedMembershipWithSlug = memberships.find(m => m.company.slug === slug);
     if (!matchedMembershipWithSlug) {
-      throw new AppException(HttpStatusCode.Unauthorized, 'Slug not match with domain.');
+      throw new AppException(HttpStatusCode.InternalServerError, 'Slug not match with domain.');
     }
     const role = matchedMembershipWithSlug.role;
     if (!allowedRoles.includes(role)) {

--- a/src/services/auth/loginService.ts
+++ b/src/services/auth/loginService.ts
@@ -49,7 +49,7 @@ export const loginService = {
     }
     const matchedMembershipWithSlug = memberships.find(m => m.company.slug === slug);
     if (!matchedMembershipWithSlug) {
-      throw new AppException(HttpStatusCode.InternalServerError, 'Slug not match with domain.');
+      throw new AppException(HttpStatusCode.Unauthorized, 'Slug not match with domain.');
     }
     const role = matchedMembershipWithSlug.role;
     if (!allowedRoles.includes(role)) {


### PR DESCRIPTION
## Change
1. Refactor error handler, format logger and response when throw error.
2. if throw error for status code = 500, record logger error message, but only return "Internal Server Error" to frontend for security reason.
3. for other status code, return detail message to fronted.

## Test
<img width="607" alt="截屏2025-07-04 19 49 10" src="https://github.com/user-attachments/assets/278ea4b9-5ced-4aea-a19f-3d1901b8bf48" />
Logger error record.
<img width="945" alt="截屏2025-07-04 19 49 29" src="https://github.com/user-attachments/assets/07ab5554-9b96-4c85-b05c-9f8eb67201bd" />


