### PR TITLE
bugfix: LA-86 error handler for code reset for specific code

### DIFF
--- a/src/controllers/auth/passwordResetController.ts
+++ b/src/controllers/auth/passwordResetController.ts
@@ -73,14 +73,7 @@ export const verifyResetCode = async (req: Request, res: Response) => {
   }
 
   // Validate the reset code
-  const validationResult = await resetCode.validateResetCode(code);
-
-  if (!validationResult.isValid) {
-    return res.status(429).json({
-      success: false,
-      message: validationResult.message,
-    });
-  }
+  await resetCode.validateResetCode(code);
 
   // Code is valid - update the password
   user.password = newPassword;

--- a/src/controllers/auth/verifyCodeController.ts
+++ b/src/controllers/auth/verifyCodeController.ts
@@ -119,11 +119,7 @@ export const verifyCode = async (req: Request, res: Response) => {
   }
 
   // Validate the code
-  const validationResult = await resetCode.validateResetCode(code);
-
-  if (!validationResult.isValid) {
-    throw new AppException(HttpStatusCode.TooManyRequests, validationResult.message);
-  }
+  await resetCode.validateResetCode(code);
 
   // Code is valid
   return res.status(200).json({

--- a/src/models/resetCode.ts
+++ b/src/models/resetCode.ts
@@ -77,7 +77,10 @@ resetCodeSchema.methods.validateResetCode = async function (
   if (this.code !== code) {
     await this.save(); // Save the incremented attempt counter
 
-    throw new AppException(HttpStatusCode.Unauthorized, 'Invalid verifyValue. Please try again.');
+    throw new AppException(
+      HttpStatusCode.Unauthorized,
+      'Invalid or expired code. Please request a new one.',
+    );
   }
 
   // If we get here, the code is valid - no return needed

--- a/src/services/auth/registerService.ts
+++ b/src/services/auth/registerService.ts
@@ -81,8 +81,5 @@ export const checkVerificationCode = async (verifyValue: string, email: string) 
     throw new AppException(HttpStatusCode.Unauthorized, 'Invalid verification value');
   }
 
-  const { isValid, message } = await resetCode.validateResetCode(verifyValue);
-  if (!isValid) {
-    throw new AppException(HttpStatusCode.Unauthorized, message);
-  }
+  await resetCode.validateResetCode(verifyValue);
 };

--- a/src/utils/invitationLink.ts
+++ b/src/utils/invitationLink.ts
@@ -101,11 +101,7 @@ export async function verifyInvitationToken(token: string): Promise<InvitationTo
     );
   }
   // Use the existing validateResetCode method to check expiration and attempts
-  const validation = await invitationRecord.validateResetCode(token);
-
-  if (!validation.isValid) {
-    throw new AppException(HttpStatusCode.Unauthorized, validation.message);
-  }
+  await invitationRecord.validateResetCode(token);
 
   // If validation is successful, delete the token (one-time use)
   await invitationRecord.deleteOne();


### PR DESCRIPTION
This pull request refactors the `validateResetCode` method to simplify its interface and error handling. The method now throws exceptions directly instead of returning an object with validation results. This change reduces boilerplate code and ensures consistent error handling across the codebase.

![image](https://github.com/user-attachments/assets/3c046b9e-cbdf-4491-a779-c2a46db7a173)
