### PR TITLE
[Chore]: LUM-12 auto remove unused import when save file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,8 @@
     // Auto fix ESLint errors on save
     "editor.codeActionsOnSave": {
         "source.fixAll": "always",
-        "source.fixAll.eslint": "always"
+        "source.fixAll.eslint": "always",
+        "source.organizeImports": "always",
     },
     "typescript.updateImportsOnFileMove.enabled": "always",
     // Use relative imports in TS


### PR DESCRIPTION
## Change
1. Add "source.organizeImports": "always" in VScode setting.

## Test
leave unused import like
<img width="379" alt="截屏2025-07-08 13 31 29" src="https://github.com/user-attachments/assets/c648bf30-b00a-4fb8-aa6d-d9a3bdbeba7e" />
Automatically remove unused imports when saving
![image](https://github.com/user-attachments/assets/258218cb-0082-4c85-a8de-73976194b1fa)
