### PR TITLE
[Bugfix]: LA-86 token error all use 401 or 403

### DIFF
--- a/src/lib/jwtUtils.ts
+++ b/src/lib/jwtUtils.ts
@@ -56,7 +56,9 @@ export const jwtUtils = {
     const decoded = jwt.verify(token, secret) as ResetTokenPayload;
 
     if (decoded.purpose !== 'password-reset') {
-      throw new AppException(HttpStatusCode.Unauthorized, 'Invalid token purpose');
+      throw new AppException(HttpStatusCode.Unauthorized, 'Invalid or expired token.', {
+        payload: 'Invalid token purpose',
+      });
     }
     return decoded;
   },

--- a/src/middleware/error/errorHandler.ts
+++ b/src/middleware/error/errorHandler.ts
@@ -35,7 +35,7 @@ function processError(err: Error, req: Request): ErrorInfo {
   if (err instanceof TokenExpiredError) {
     return {
       statusCode: 401,
-      message: 'Token has expired',
+      message: 'Invalid or  expired token',
       logMessage: 'Token has expired',
       logTag: 'TokenExpired Error',
     };
@@ -44,8 +44,8 @@ function processError(err: Error, req: Request): ErrorInfo {
   // JWT token error
   if (err instanceof JsonWebTokenError) {
     return {
-      statusCode: 500,
-      message: 'Internal Server Error',
+      statusCode: 401,
+      message: 'Invalid or  expired token',
       logMessage: 'Invalid token',
       logTag: 'JsonWebToken Error',
     };

--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -9,7 +9,9 @@ export const authService = {
     const payload = jwtUtils.verifyAccessToken(token);
     const user = await UserModel.find({ email: payload?.email });
     if (!user) {
-      throw new AppException(HttpStatusCode.Forbidden);
+      throw new AppException(HttpStatusCode.Forbidden, 'Invalid or  expired token', {
+        payload: `User not found with email: ${payload?.email} of token`,
+      });
     }
     return user;
   },

--- a/src/utils/invitationLink.ts
+++ b/src/utils/invitationLink.ts
@@ -1,8 +1,7 @@
 import { HttpStatusCode } from 'axios';
 import jwt, { JwtPayload, Secret, SignOptions } from 'jsonwebtoken';
 
-import { EXPIRES_TIME_CONFIG, ROLE, RoleType } from '../config';
-import { config } from '../config';
+import { config, EXPIRES_TIME_CONFIG, ROLE, RoleType } from '../config';
 import AppException from '../exceptions/appException';
 import ResetCodeModel from '../models/resetCode';
 import { VerifyCodeType } from '../types/invitation';
@@ -82,10 +81,9 @@ export async function verifyInvitationToken(token: string): Promise<InvitationTo
   const decoded = jwt.verify(token, secret) as InvitationTokenPayload;
 
   if (decoded.purpose !== 'invitation') {
-    throw new AppException(
-      HttpStatusCode.InternalServerError,
-      'Invalid token purpose. This is not an invitation token.',
-    );
+    throw new AppException(HttpStatusCode.Unauthorized, 'Invalid or  expired token', {
+      payload: 'Invalid token purpose. This is not an invitation token.',
+    });
   }
   // Check if token exists in database
   const invitationRecord = await ResetCodeModel.findOne({
@@ -95,10 +93,9 @@ export async function verifyInvitationToken(token: string): Promise<InvitationTo
   });
 
   if (!invitationRecord) {
-    throw new AppException(
-      HttpStatusCode.InternalServerError,
-      'Invitation token not found or has been used.',
-    );
+    throw new AppException(HttpStatusCode.Unauthorized, 'Invalid or  expired token', {
+      payload: 'Invitation token not found or has been used.',
+    });
   }
   // Use the existing validateResetCode method to check expiration and attempts
   await invitationRecord.validateResetCode(token);


### PR DESCRIPTION
##Change
1. All token error return 401 or 403 and message "Invalid or expired token" to frontend.