### PR TITLE
[Chore]: LA-95 change Eslint rules allow TODO comment

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,18 +6,17 @@ const noDevNotesRule = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Disallow committing code with TODO, FIXME, WTF comments',
+      description: 'Disallow committing code with FIXME, WTF comments',
       recommended: true,
     },
     messages: {
       foundDevNote:
-        '❌ It is prohibited to submit comments with obvious development notes or questions, such as TODO, FIXME, WTF, etc. Please handle them before submitting.',
+        '❌ It is prohibited to submit comments with obvious development notes or questions, such as  FIXME, WTF, etc. Please handle them before submitting.',
     },
   },
   create(context) {
     const sourceCode = context.getSourceCode();
     const devNotePatterns = [
-      /\bTODO\b/i,
       /\bFIXME\b/i,
       /\bWTF\b/i,
       /\bHACK\b/i,

--- a/src/controllers/dashboardController.ts
+++ b/src/controllers/dashboardController.ts
@@ -18,7 +18,7 @@ export const dashboardController = {
 
     const currentUserInfo = await userService.getCurrentUserInfo(req.user.id, req.companyId);
 
-    //mock data for dashboard display(replace later)
+    //TODO: mock data for dashboard display(replace later)
     const dashboardData = {
       currentUserInfo,
       totalLearners: companyUsage?.currentLearners ?? DEFAULT_MOCK_COUNT,


### PR DESCRIPTION
##Background
According to the document to set Eslint rules: 
<img width="1442" height="440" alt="image" src="https://github.com/user-attachments/assets/46c9223d-8796-4313-ab33-849d500609a6" />
When submitting changes to git, unfinished code such as TODO comments are not allowed. However, some tasks do not belong to the current sprint, but must be reminded to be processed in the future, so TODO comments should keep.

## Change
1. Change Eslint rules allow TODO comment.
2. Keep TODO for mock data and TODO for api change name.