### PR TITLE
[Bugfix]: LA-97 change ResetPassword api field: 'code' to 'verifyValue' same with signup

### DIFF
--- a/src/controllers/auth/passwordResetController.ts
+++ b/src/controllers/auth/passwordResetController.ts
@@ -2,21 +2,33 @@ import AppException from '@src/exceptions/appException';
 import ResetCodeModel from '@src/models/resetCode';
 import UserModel from '@src/models/user';
 import { VerifyCodeType } from '@src/types/invitation';
+import logger from '@src/utils/logger';
 import { HttpStatusCode } from 'axios';
 import { Request, Response } from 'express';
+
+/**
+ * Reset password - This is now combined with verifyResetCode
+ * This function is kept as a placeholder so existing routes still work
+ * It redirects to the combined verifyResetCode function
+ */
+export const resetPassword = async (req: Request, res: Response) => {
+  // This function now delegates to verifyResetCode for consistency
+  return verifyResetCode(req, res);
+};
 
 /**
  * Combined verify code and reset password
  * Validates the verification value and resets the password in one step
  */
 export const verifyResetCode = async (req: Request, res: Response) => {
-  const { email, code, newPassword } = req.body;
+  const { email, verifyValue, newPassword } = req.body;
 
   // Find user by email
   const user = await UserModel.findOne({ email }).exec();
 
   // User not exist still return true
   if (!user) {
+    logger.error(`Reset password: user not exist with email: ${email}`);
     return res.status(200).json({
       success: true,
     });
@@ -32,12 +44,12 @@ export const verifyResetCode = async (req: Request, res: Response) => {
     throw new AppException(
       HttpStatusCode.NotFound,
       'Invalid or expired code. Please request a new one.',
-      { field: 'verificationCode' },
+      { field: 'verificationCode', payload: `ResetCode not exist with email ${email} for ${VerifyCodeType.VERIFICATION}` },
     );
   }
 
   // Validate the reset code
-  await resetCode.validateResetCode(code);
+  await resetCode.validateResetCode(verifyValue);
 
   // Code is valid - update the password
   user.password = newPassword;
@@ -56,12 +68,4 @@ export const verifyResetCode = async (req: Request, res: Response) => {
   });
 };
 
-/**
- * Reset password - This is now combined with verifyResetCode
- * This function is kept as a placeholder so existing routes still work
- * It redirects to the combined verifyResetCode function
- */
-export const resetPassword = async (req: Request, res: Response) => {
-  // This function now delegates to verifyResetCode for consistency
-  return verifyResetCode(req, res);
-};
+

--- a/src/controllers/auth/passwordResetController.ts
+++ b/src/controllers/auth/passwordResetController.ts
@@ -44,7 +44,10 @@ export const verifyResetCode = async (req: Request, res: Response) => {
     throw new AppException(
       HttpStatusCode.NotFound,
       'Invalid or expired code. Please request a new one.',
-      { field: 'verificationCode', payload: `ResetCode not exist with email ${email} for ${VerifyCodeType.VERIFICATION}` },
+      {
+        field: 'verificationCode',
+        payload: `ResetCode not exist with email ${email} for ${VerifyCodeType.VERIFICATION}`,
+      },
     );
   }
 
@@ -67,5 +70,3 @@ export const verifyResetCode = async (req: Request, res: Response) => {
     message: 'Password has been reset successfully',
   });
 };
-
-

--- a/src/models/resetCode.ts
+++ b/src/models/resetCode.ts
@@ -81,7 +81,7 @@ resetCodeSchema.methods.validateResetCode = async function (
     throw new AppException(
       HttpStatusCode.Unauthorized,
       'Invalid or expired code. Please request a new one.',
-      { field: 'verificationCode', payload: 'Invalid code' },
+      { field: 'verificationCode', payload: `Invalid code ${code} not match with ${this.code}` },
     );
   }
 

--- a/src/services/auth/registerService.ts
+++ b/src/services/auth/registerService.ts
@@ -82,4 +82,5 @@ export const checkVerificationCode = async (verifyValue: string, email: string) 
   }
 
   await resetCode.validateResetCode(verifyValue);
+  await resetCode.deleteOne();
 };


### PR DESCRIPTION
## Background
In order to maintain consistency with the Signup API, the resetPassword field 'code' has been uniformly changed to 'verifiValue'.
## Change
1. For readability, place the resetPassword method at the top of PassowordResetController.ts.
2. Change field 'code' to 'verifyValue'.
3. For quick debugging, add detailed error information to the logger.
## Test
