### PR TITLE
[Bugfix]: LA-98 separate error message for usename and email conflict

### DIFF
--- a/src/middleware/validation/adminRegistrationPreCheck.ts
+++ b/src/middleware/validation/adminRegistrationPreCheck.ts
@@ -1,8 +1,8 @@
 import { RegisterUserInput } from '@src/controllers/auth/registerController';
 import AppException from '@src/exceptions/appException';
 import CompanyModel from '@src/models/company';
-import UserModel from '@src/models/user';
 import { checkVerificationCode } from '@src/services/auth/registerService';
+import { userService } from '@src/services/userService';
 import { extractCompanySlug } from '@src/utils/extractCompanySlugFromEmail';
 import { getSafePendingUserData, setPendingUserData } from '@src/utils/storagePendingUser';
 import { HttpStatusCode } from 'axios';
@@ -15,22 +15,7 @@ export const adminRegistrationPreCheck = async (
 ) => {
   const { email, username, verifyValue } = req.body;
 
-  // check user with company exist
-  const userExistWithEmail = await UserModel.findOne({ email });
-  if (userExistWithEmail) {
-    // user and company all exist
-    throw new AppException(HttpStatusCode.Conflict, 'Email already registered. Please log in.', {
-      field: 'email',
-    });
-  }
-  const userExistWithUsername = await UserModel.findOne({ username });
-  if (userExistWithUsername) {
-    throw new AppException(
-      HttpStatusCode.Conflict,
-      'Username already in use. Try a different one.',
-      { field: 'username' },
-    );
-  }
+  await userService.checkUserConflict(email, username);
 
   // check company
   const companySlug = await extractCompanySlug(email);

--- a/src/services/auth/registerService.ts
+++ b/src/services/auth/registerService.ts
@@ -58,6 +58,7 @@ export const registerService = {
 
   // Register learner user and create learner membership for specific organization
   learnerRegister: async (userInput: RegisterUserInput, organizationId: string) => {
+    await userService.checkUserConflict(userInput.email, userInput.username);
     await checkVerificationCode(userInput.verifyValue, userInput.email);
 
     const { newUser, refreshToken, accessToken } = await createUserAndTokens(userInput);


### PR DESCRIPTION
## Background
The previous error message checking for user existence did not specify in detail whether it was an email conflict or a username conflict.
To maintain consistency, all User registrations (except for teachers who are invited) are separately prompted with whether the username already exists or the email already exists.

## Change
1. Extract a method for check if the user exists with email and username.
2. Call checkUserConflict method in adminPreCheck, learner register and createUser method.

## Test
Test case processing.