### PR TITLE
【Test】: LA-97 resetpassword test case

### DIFF
--- a/loaders/app.ts
+++ b/loaders/app.ts
@@ -43,7 +43,9 @@ function wrapRoutes(router: Router): Router {
       for (const routeLayer of layer.route.stack) {
         const handler = routeLayer.handle;
         if (handler.constructor.name === 'AsyncFunction') {
-          routeLayer.handle = catchAllErrors(handler);
+          routeLayer.handle = catchAllErrors(
+            handler as (req: Request, res: Response, next: NextFunction) => void | Promise<void>,
+          );
         }
       }
     }

--- a/test/__test__/builders/resetCodeBuilder.ts
+++ b/test/__test__/builders/resetCodeBuilder.ts
@@ -1,0 +1,54 @@
+import ResetCodeModel, { ResetCode } from '@src/models/resetCode';
+import { VerifyCodeType } from '@src/types/invitation';
+
+export default class ResetCodeBuilder {
+  private resetCode: Partial<ResetCode>;
+
+  constructor() {
+    this.resetCode = {
+      email: 'test@example.com',
+      code: '888888',
+      verifyType: VerifyCodeType.VERIFICATION,
+      expiresAt: new Date(Date.now() + 15 * 60 * 1000), // default expird in 15 mins
+      attempts: 0,
+    };
+  }
+
+  withEmail(email: string): this {
+    this.resetCode.email = email;
+    return this;
+  }
+
+  withCode(code: string): this {
+    this.resetCode.code = code;
+    return this;
+  }
+
+  withVerifyType(type: VerifyCodeType): this {
+    this.resetCode.verifyType = type;
+    return this;
+  }
+
+  withExpiry(minutesFromNow: number): this {
+    this.resetCode.expiresAt = new Date(Date.now() + minutesFromNow * 60 * 1000);
+    return this;
+  }
+
+  withPastExpiry(): this {
+    this.resetCode.expiresAt = new Date(Date.now() - 5 * 60 * 1000);
+    return this;
+  }
+
+  withAttempts(attempts: number): this {
+    this.resetCode.attempts = attempts;
+    return this;
+  }
+
+  build(): ResetCode {
+    return new ResetCodeModel(this.resetCode) as ResetCode;
+  }
+
+  async save(): Promise<ResetCode> {
+    return await this.build().save();
+  }
+}

--- a/test/__test__/resetPassword.test.ts
+++ b/test/__test__/resetPassword.test.ts
@@ -1,0 +1,133 @@
+/// <reference types="jest" />
+import ResetCodeModel from '@src/models/resetCode';
+import UserModel from '@src/models/user';
+import { VerifyCodeType } from '@src/types/invitation';
+import ResetCodeBuilder from '@test/__test__/builders/resetCodeBuilder';
+import request from 'supertest';
+
+import { getApplication } from '../setup/app';
+import { getDefaultUser } from '../setup/jest-setup';
+
+declare const describe: (name: string, fn: () => void) => void;
+declare const it: (name: string, fn: () => Promise<void>) => void;
+declare const expect: any;
+
+describe('Reset password', () => {
+  it('should successfully reset the password when the user exists with valid code', async () => {
+    const defaultUser = getDefaultUser();
+    await new ResetCodeBuilder()
+      .withEmail(defaultUser.email)
+      .withCode('888888')
+      .withVerifyType(VerifyCodeType.VERIFICATION)
+      .save();
+
+    const response = await request(getApplication()).post('/api/v1/auth/reset-password').send({
+      email: defaultUser.email,
+      newPassword: '55647Aabb@',
+      verifyValue: '888888',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.message).toBe('Password has been reset successfully');
+
+    //The assertion verification value has been deleted
+    const verifyValueInDB = await ResetCodeModel.findOne({ email: defaultUser.email });
+    expect(verifyValueInDB).toBeNull();
+
+    //Claiming that user refreshToken has been cleared
+    const user = await UserModel.findOne({ email: defaultUser.email }).exec();
+    expect(user?.refreshToken).toBeUndefined();
+  });
+
+  it('should return true when the user not exists', async () => {
+    const response = await request(getApplication()).post('/api/v1/auth/reset-password').send({
+      email: 'test@notexist.com',
+      newPassword: '55647Aabb@',
+      verifyValue: '888888',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+  });
+
+  it('should throw 401 unauthorized error when verification code not exists', async () => {
+    const defaultUser = getDefaultUser();
+    await ResetCodeModel.deleteMany({ email: defaultUser.email });
+
+    const response = await request(getApplication()).post('/api/v1/auth/reset-password').send({
+      email: defaultUser.email,
+      newPassword: '55647Aabb@',
+      verifyValue: '888888',
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toMatch(/Invalid or expired code. Please request a new one./);
+    expect(response.body.field).toBe('verificationCode');
+  });
+
+  it('should throw 401 invalid error if verification code is invalid', async () => {
+    const defaultUser = getDefaultUser();
+    await new ResetCodeBuilder()
+      .withEmail(defaultUser.email)
+      .withVerifyType(VerifyCodeType.VERIFICATION)
+      .withCode('888888')
+      .save();
+    const response = await request(getApplication()).post('/api/v1/auth/reset-password').send({
+      email: defaultUser.email,
+      newPassword: '55647Aabb@',
+      verifyValue: 'wrongCode',
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toMatch(/Invalid or expired code/);
+    expect(response.body.field).toBe('verificationCode');
+
+    const code = await ResetCodeModel.findOne({ email: defaultUser.email });
+    expect(code?.attempts).toBe(1);
+  });
+
+  it('should throw 429 too many requests error after 5 invalid attempts', async () => {
+    const defaultUser = getDefaultUser();
+    await new ResetCodeBuilder()
+      .withEmail(defaultUser.email)
+      .withCode('888888')
+      .withVerifyType(VerifyCodeType.VERIFICATION)
+      .withAttempts(4)
+      .save();
+
+    const response = await request(getApplication()).post('/api/v1/auth/reset-password').send({
+      email: defaultUser.email,
+      newPassword: '55647Aabb@',
+      verifyValue: 'wrongCodeAgain',
+    });
+
+    expect(response.status).toBe(429);
+    expect(response.body.message).toBe(
+      'Too many incorrect attempts. Please request a new verification value.',
+    );
+
+    const code = await ResetCodeModel.findOne({ email: defaultUser.email });
+    expect(code).toBeNull();
+  });
+
+  it('should throw 401 unauthorized error if reset code expired', async () => {
+    const defaultUser = getDefaultUser();
+    await new ResetCodeBuilder()
+      .withEmail(defaultUser.email)
+      .withCode('888888')
+      .withVerifyType(VerifyCodeType.VERIFICATION)
+      .withExpiry(-10)
+      .save();
+
+    const response = await request(getApplication()).post('/api/v1/auth/reset-password').send({
+      email: defaultUser.email,
+      newPassword: '55647Aabb@',
+      verifyValue: '888888',
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Invalid or expired code. Please request a new one.');
+    expect(response.body.field).toBe('verificationCode');
+  });
+});

--- a/test/setup/app.ts
+++ b/test/setup/app.ts
@@ -1,4 +1,6 @@
-import express, { type Application } from 'express';
+import { type Application } from 'express';
+
+import app from '../../loaders/app';
 
 let application: Application | null = null;
 
@@ -8,15 +10,7 @@ export const loadApp = async (): Promise<Application> => {
   }
 
   // Create a simple express app for testing
-  application = express();
-
-  // Add basic middleware for testing
-  application.use(express.json());
-  application.use(express.urlencoded({ extended: true }));
-
-  // Import and setup routes directly from source (not compiled)
-  const v1Router = await import('../../src/handlers/v1/api');
-  application.use('/api/v1', v1Router.default);
+  application = app;
 
   return application;
 };

--- a/test/setup/jest-setup.ts
+++ b/test/setup/jest-setup.ts
@@ -1,5 +1,8 @@
 /// <reference types="jest" />
 
+import { HttpStatusCode } from 'axios';
+
+import AppException from '../../src/exceptions/appException';
 import CompanyBuilder, { type CompanyDocument } from '../__test__/builders/companyBuilder';
 import UserBuilder, { type UserDocument } from '../__test__/builders/userBuilder';
 import * as app from './app';
@@ -20,9 +23,15 @@ const createDefaultData = async (): Promise<void> => {
     .withUsername('defaultowner')
     .withFirstName('Default')
     .withLastName('Owner')
+    .withPassword('123@Password')
     .save();
 
-  defaultCompany = await new CompanyBuilder().withOwner(defaultUser._id).save();
+  defaultCompany = await new CompanyBuilder()
+    .withCompanyName('testCompany')
+    .withPlan('free')
+    .withSlug('default-company')
+    .withOwner(defaultUser._id)
+    .save();
 };
 
 beforeAll(async () => {
@@ -45,5 +54,15 @@ afterAll(async () => {
 });
 
 // Export read-only getters
-export const getDefaultUser = (): UserDocument | null => defaultUser;
-export const getDefaultCompany = (): CompanyDocument | null => defaultCompany;
+export const getDefaultUser = (): UserDocument => {
+  if (!defaultUser) {
+    throw new AppException(HttpStatusCode.InternalServerError, 'Default user creation failed!');
+  }
+  return defaultUser;
+};
+export const getDefaultCompany = (): CompanyDocument => {
+  if (!defaultCompany) {
+    throw new AppException(HttpStatusCode.InternalServerError, 'Default company creation failed!');
+  }
+  return defaultCompany;
+};

--- a/test/testTeardownGlobals.ts
+++ b/test/testTeardownGlobals.ts
@@ -1,3 +1,5 @@
+import 'tsconfig-paths/register';
+
 import * as app from './setup/app';
 import * as db from './setup/db';
 


### PR DESCRIPTION
## Background
Change reset password field 'code' to 'verifyValue'

## Change
1. Add handler type for typescript limit.
2. Add resetCode builder for test case.
3. Add reset password test case (not include Joi validation).
4. Fix app.ts for test, import app.ts of loaders not refactor new one for test.
5. Refactor generate default user and company, add null check.
6. Add absolute path resolve for : tsconfig-paths/register in test/testTeardownGlobals.ts.

## Test
<img width="378" height="53" alt="Screenshot 2025-07-18 at 20 51 09" src="https://github.com/user-attachments/assets/65c1f04f-6365-4133-a573-e90dabd0a674" />
