### PR TITLE
[Feature]: LA-101 verify domain

### DIFF
--- a/src/controllers/auth/authController.ts
+++ b/src/controllers/auth/authController.ts
@@ -1,3 +1,5 @@
+import AppException from '@src/exceptions/appException';
+import { companyService } from '@src/services/companyService';
 import { VerifyInvitationLinkExist } from '@src/utils/invitationLink';
 import { HttpStatusCode } from 'axios';
 import { Request, Response } from 'express';
@@ -9,6 +11,21 @@ export const verifyAuthToken = async (req: Request, res: Response) => {
   await authService.verifyToken(token);
 
   await VerifyInvitationLinkExist(token);
+
+  return res.sendStatus(HttpStatusCode.Ok);
+};
+
+export const verifyDomain = async (req: Request, res: Response) => {
+  const origin = req.headers.origin ?? `${req.protocol}://${req.hostname}`;
+  const hostname = new URL(origin).hostname.toLowerCase();
+
+  const comapnySlug = await authService.verifyDomainGetSlug(hostname);
+  const existCompany = await companyService.getCompanyBySlug(comapnySlug);
+  if (!existCompany) {
+    throw new AppException(HttpStatusCode.NotFound, 'Page not found', {
+      payload: `Company not found for slug: ${comapnySlug} of domain`,
+    });
+  }
 
   return res.sendStatus(HttpStatusCode.Ok);
 };

--- a/src/handlers/v1/api.ts
+++ b/src/handlers/v1/api.ts
@@ -1,6 +1,7 @@
+import { adminRegistrationPreCheck } from '@src/middleware/validation/adminRegistrationPreCheck';
 import { Router } from 'express';
 
-import { verifyAuthToken } from '../../controllers/auth/authController';
+import { verifyAuthToken, verifyDomain } from '../../controllers/auth/authController';
 import { loginEnterprise, loginLearner } from '../../controllers/auth/loginController';
 import { userLogout } from '../../controllers/auth/logoutController';
 import { resetPassword } from '../../controllers/auth/passwordResetController';
@@ -22,7 +23,6 @@ import {
 } from '../../middleware/fileUploader';
 import { saas } from '../../middleware/saasMiddleware';
 import { refreshToken } from '../../middleware/tokenHandler';
-import { adminRegistrationPreCheck } from '../../middleware/validation/adminRegistrationPreCheck';
 import { validateBody } from '../../middleware/validation/validationMiddleware';
 import { registerRoutes } from '../../utils/registerRoutes';
 import { companyValidationSchema } from '../../validations/companyValidation';
@@ -89,6 +89,11 @@ registerRoutes(router, [
     method: 'post',
     path: '/auth/token',
     handler: verifyAuthToken,
+  },
+  {
+    method: 'get',
+    path: '/auth/verify-domain',
+    handler: verifyDomain,
   },
 ]);
 

--- a/src/middleware/saasMiddleware.ts
+++ b/src/middleware/saasMiddleware.ts
@@ -1,3 +1,5 @@
+import { authService } from '@src/services/auth/authService';
+import { companyService } from '@src/services/companyService';
 import { HttpStatusCode } from 'axios';
 import { NextFunction, Request, Response } from 'express';
 
@@ -25,21 +27,9 @@ export const saas = async (req: Request, res: Response, next: NextFunction) => {
     throw new AppException(HttpStatusCode.InternalServerError, `Invalid hostname: ${hostname}`);
   }
 
-  const firstDotIndex = hostname.indexOf('.');
-  if (firstDotIndex === -1) {
-    // e.g., "localhost", no subdomain
-    throw new AppException(
-      HttpStatusCode.InternalServerError,
-      `Missing subdomain: ${firstDotIndex}`,
-    );
-  }
+  const slug = await authService.verifyDomainGetSlug(hostname);
 
-  const slug = hostname.substring(0, firstDotIndex);
-  if (!slug) {
-    throw new AppException(HttpStatusCode.InternalServerError, `Invalid subdomain: ${slug}`);
-  }
-
-  const existCompany = await CompanyModel.findOne({ slug }).lean();
+  const existCompany = await companyService.getCompanyBySlug(slug);
   if (!existCompany) {
     throw new AppException(
       HttpStatusCode.InternalServerError,

--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -16,4 +16,31 @@ export const authService = {
     }
     return user;
   },
+
+  verifyDomainGetSlug: async (hostname: string) => {
+    const domainParts = hostname.split('.');
+    const domain = domainParts.slice(-2).join('.');
+    const allowedMainDomains = ['lumaai.com', 'lumaai.localhost'];
+
+    if (domainParts.length !== 3) {
+      throw new AppException(HttpStatusCode.NotFound, 'Page not found', {
+        payload: `Invalid domain structure: ${hostname}. Expected format is slug.lumaai.com`,
+      });
+    }
+
+    if (!allowedMainDomains.includes(domain)) {
+      throw new AppException(HttpStatusCode.NotFound, 'Page not found', {
+        payload: `Invalid domain: ${hostname}, not include lumaai.com`,
+      });
+    }
+
+    const slug = domainParts[0];
+    if (!slug) {
+      throw new AppException(HttpStatusCode.NotFound, 'Page not found', {
+        payload: `Missing subdomain slug: ${hostname}`,
+      });
+    }
+
+    return slug;
+  },
 };

--- a/src/services/companyService.ts
+++ b/src/services/companyService.ts
@@ -45,4 +45,12 @@ export const companyService = {
     await company.deleteOne(); //Trigger pre deleteOne hook, also delete membership
     return true;
   },
+
+  getCompanyBySlug: async (slug: string) => {
+    const existCompany = await CompanyModel.findOne({ slug }).lean();
+    if (!existCompany) {
+      return false;
+    }
+    return existCompany;
+  },
 };

--- a/test/__test__/verifySubdomain.test.ts
+++ b/test/__test__/verifySubdomain.test.ts
@@ -1,0 +1,72 @@
+/// <reference types="jest" />
+
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import CompanyModel from '@src/models/company';
+import CompanyBuilder from '@test/__test__/builders/companyBuilder';
+import { getApplication } from '@test/setup/app';
+import { Application } from 'express';
+import request from 'supertest';
+
+describe('Verify domain and company exist by slug', () => {
+  const apiURL = '/api/v1/auth/verify-domain';
+  const originURL = 'http://default-company.lumaai.com';
+  let app: Application;
+
+  beforeEach(async () => {
+    app = getApplication();
+  });
+
+  it('should return 200 for valid domain and existing company ', async () => {
+    const response = await request(app).get(apiURL).set('origin', originURL);
+
+    expect(response.status).toBe(200);
+  });
+
+  it('should return 200 for domain end with localhost ', async () => {
+    const response = await request(app)
+      .get(apiURL)
+      .set('origin', 'http://default-company.lumaai.localhost:8000');
+
+    expect(response.status).toBe(200);
+  });
+
+  it('should return 404 if company slug does not exist', async () => {
+    await CompanyModel.deleteMany({});
+
+    const response = await request(app).get(apiURL).set('origin', originURL);
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe('Page not found');
+  });
+
+  it('should return 404 if subdomain is missing (e.g. http://lumaai.com)', async () => {
+    await new CompanyBuilder().withSlug('lumaai').save();
+
+    const response = await request(app).get(apiURL).set('origin', 'http://lumaai.com');
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe('Page not found');
+  });
+
+  it('should return 404 if invalid domain (e.g. http://.com)', async () => {
+    const response = await request(app).get(apiURL).set('origin', 'http://.com');
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe('Page not found');
+  });
+
+  it('should return 404 for multi-level subdomain (e.g. http://a.b.lumaai.com)', async () => {
+    const response = await request(app).get(apiURL).set('origin', 'http://a.b.lumaai.com');
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe('Page not found');
+  });
+
+  it('should return 404 for disallowed domain (e.g. http://abc.fake.com)', async () => {
+    await new CompanyBuilder().withSlug('abc').save();
+    const response = await request(app).get(apiURL).set('origin', 'http://abc.fake.com');
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe('Page not found');
+  });
+});


### PR DESCRIPTION
Background
Verify domain format and get slug form domain, If company not registed with slug, show 404 page.

Change
Add verifyDomainGetCompanySLug service, throw 404 error for domain invalid or company not exist by slug in DB.
Add verifyDomain controller, return 200 if valid domain and company exist with slug.
Add getCompanyBySlug  method in companyService.
Refactor Saas middleware, call verifyDomain abd getCompanyBySlug inside.
Add api: /api/v1/auth/verify-domain.

Test
[
<img width="628" height="199" alt="截屏2025-07-25 19 03 44" src="https://github.com/user-attachments/assets/b0c50db3-4769-4602-b097-185c8265a191" />
](url)