### PR TITLE
[refactor]: LA-105 owner register

### DIFF
--- a/src/handlers/v1/api.ts
+++ b/src/handlers/v1/api.ts
@@ -107,7 +107,7 @@ const logoUploader = createFileUploader({
 registerRoutes(router, [
   {
     method: 'post',
-    path: '/auth/signup/institution', //TODO: Change to /owner/register
+    path: '/auth/signup/institution-owner',
     middlewares: [
       wrapMulterMiddleware(logoUploader.single('logo')),
       validateBody(companyValidationSchema),

--- a/src/middleware/validation/adminRegistrationPreCheck.ts
+++ b/src/middleware/validation/adminRegistrationPreCheck.ts
@@ -3,7 +3,7 @@ import AppException from '@src/exceptions/appException';
 import CompanyModel from '@src/models/company';
 import { checkVerificationCode } from '@src/services/auth/registerService';
 import { userService } from '@src/services/userService';
-import { extractCompanySlug } from '@src/utils/extractCompanySlugFromEmail';
+import { extractCompanySlugFromEmail } from '@src/utils/extractCompanySlugFromEmail';
 import { getSafePendingUserData, setPendingUserData } from '@src/utils/storagePendingUser';
 import { HttpStatusCode } from 'axios';
 import { NextFunction, Request, Response } from 'express';
@@ -18,7 +18,7 @@ export const adminRegistrationPreCheck = async (
   await userService.checkUserConflict(email, username);
 
   // check company
-  const companySlug = await extractCompanySlug(email);
+  const companySlug = await extractCompanySlugFromEmail(email);
 
   // check verification value, error will be thrown if verification value is not valid
   await checkVerificationCode(verifyValue, email);

--- a/src/services/membershipService.ts
+++ b/src/services/membershipService.ts
@@ -3,7 +3,7 @@ import AppException from '@src/exceptions/appException';
 import CompanyModel from '@src/models/company';
 import MembershipModel, { Membership } from '@src/models/membership';
 import { User } from '@src/models/user';
-import { extractCompanySlug } from '@src/utils/extractCompanySlugFromEmail';
+import { extractCompanySlugFromEmail } from '@src/utils/extractCompanySlugFromEmail';
 import { HttpStatusCode } from 'axios';
 import { Types } from 'mongoose';
 
@@ -43,7 +43,7 @@ export const membershipService = {
   },
 
   createAdminMembershipByUser: async (user: User, role: RoleType): Promise<Membership> => {
-    const slug = await extractCompanySlug(user.email);
+    const slug = await extractCompanySlugFromEmail(user.email);
 
     const existCompany = await CompanyModel.findOne({ slug });
     if (!existCompany) {

--- a/src/utils/extractCompanySlugFromEmail.ts
+++ b/src/utils/extractCompanySlugFromEmail.ts
@@ -4,7 +4,7 @@ import { HttpStatusCode } from 'axios';
 import freemail from 'freemail';
 import { parse } from 'psl';
 
-export const extractCompanySlug = async (email: string): Promise<string> => {
+export const extractCompanySlugFromEmail = async (email: string): Promise<string> => {
   const domain = email.split('@')[1]?.toLowerCase();
   // email required
   if (!domain) {

--- a/test/__test__/signUpCompanyOwner.test.ts
+++ b/test/__test__/signUpCompanyOwner.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { RegisterUserInput } from '@src/controllers/auth/registerController';
+import { getPendingUserData, setPendingUserData } from '@src/utils/storagePendingUser';
+import { getApplication } from '@test/setup/app';
+import { getDefaultUser } from '@test/setup/jest-setup';
+import { Application } from 'express';
+import request from 'supertest';
+
+describe('Sign Up Company and Owner', () => {
+  const apiPath = '/api/v1/auth/signup/institution-owner';
+  const testEmail = 'owner@nonexist-company.com';
+  const verifyValue = '888888';
+  const companyName = 'testCompany';
+
+  let app: Application;
+
+  beforeEach(() => {
+    app = getApplication();
+  });
+
+  it('should create a company and owner user successfully ', async () => {
+    const pendingUser: RegisterUserInput = {
+      firstName: 'Test',
+      lastName: 'User',
+      username: 'Owner',
+      password: '123@Password',
+      email: testEmail,
+      verifyValue,
+    };
+    setPendingUserData(pendingUser);
+    expect(getPendingUserData()).toEqual(pendingUser);
+
+    const response = await request(app).post(apiPath).send({
+      companyName,
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.data).toMatchObject({
+      user: {
+        username: 'Owner',
+        email: testEmail,
+      },
+      company: {
+        companyName: companyName,
+        slug: 'nonexist-company',
+      },
+      membership: {
+        role: 'admin',
+      },
+    });
+
+    expect(getPendingUserData()).toBeNull();
+  });
+
+  it('should return 400 if missing owner registration data', async () => {
+    const response = await request(app).post(apiPath).send({
+      companyName,
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(
+      'Missing user registration data, please return Admin Signup Page.',
+    );
+  });
+
+  it('should return 422 for email without "@" symbol', async () => {
+    const pendingUser: RegisterUserInput = {
+      firstName: 'Test',
+      lastName: 'User',
+      username: 'Owner',
+      password: '123@Password',
+      email: 'ownernonexist-company.com',
+      verifyValue,
+    };
+
+    setPendingUserData(pendingUser);
+    expect(getPendingUserData()).toEqual(pendingUser);
+
+    const response = await request(app).post(apiPath).send({
+      companyName,
+    });
+
+    expect(response.status).toBe(422);
+    expect(response.body.message).toBe('Please provide a valid email address');
+  });
+
+  it('should return 422 if public email not work email', async () => {
+    const pendingUser: RegisterUserInput = {
+      firstName: 'Test',
+      lastName: 'User',
+      username: 'Owner',
+      password: '123@Password',
+      email: 'owner@gmail.com',
+      verifyValue,
+    };
+
+    setPendingUserData(pendingUser);
+    expect(getPendingUserData()).toEqual(pendingUser);
+
+    const response = await request(app).post(apiPath).send({
+      companyName,
+    });
+
+    expect(response.status).toBe(422);
+    expect(response.body.message).toBe('Public email providers are not allowed');
+    expect(response.body.field).toBe('email');
+  });
+
+  it('should return 422 for email without "." symbol', async () => {
+    const pendingUser: RegisterUserInput = {
+      firstName: 'Test',
+      lastName: 'User',
+      username: 'Owner',
+      password: '123@Password',
+      email: 'owner@nonexist-companycom',
+      verifyValue,
+    };
+
+    setPendingUserData(pendingUser);
+    expect(getPendingUserData()).toEqual(pendingUser);
+
+    const response = await request(app).post(apiPath).send({
+      companyName,
+    });
+
+    expect(response.status).toBe(422);
+    expect(response.body.message).toBe('Please provide a valid email address');
+  });
+
+  it('should return 409 if email conflict', async () => {
+    const defaultUser = getDefaultUser();
+    const pendingUser: RegisterUserInput = {
+      firstName: 'Test',
+      lastName: 'User',
+      username: 'Owner',
+      password: '123@Password',
+      email: defaultUser.email,
+      verifyValue,
+    };
+
+    setPendingUserData(pendingUser);
+    expect(getPendingUserData()).toEqual(pendingUser);
+
+    const response = await request(app).post(apiPath).send({
+      companyName,
+    });
+
+    expect(response.status).toBe(409);
+    expect(response.body.message).toBe('Email already registered. Please log in.');
+    expect(response.body.field).toBe('email');
+  });
+
+  it('should return 409 if username conflict', async () => {
+    const defaultUser = getDefaultUser();
+    const pendingUser: RegisterUserInput = {
+      firstName: 'Test',
+      lastName: 'User',
+      username: defaultUser.username,
+      password: '123@Password',
+      email: testEmail,
+      verifyValue,
+    };
+
+    setPendingUserData(pendingUser);
+    expect(getPendingUserData()).toEqual(pendingUser);
+
+    const response = await request(app).post(apiPath).send({
+      companyName,
+    });
+
+    expect(response.status).toBe(409);
+    expect(response.body.message).toBe('Username already in use. Try a different one.');
+    expect(response.body.field).toBe('username');
+  });
+});


### PR DESCRIPTION
## Background
The API for registering a company is not only for registering the company, but also for registering the admin user, new company, and membership, and setting the admin user as the owner of the company.

## Change
1. Rename extractSlug method to distinguish between retrieving slug from domain or email.
2. Adjust the order of the registration methods for the three roles to ensure consistency between the controller and service.
3. Refactor owner register based on the controller and service structure.
4. Change api.
5. Integration test for owner gister.

## Test
<img width="523" height="242" alt="Screenshot 2025-07-28 at 21 48 24" src="https://github.com/user-attachments/assets/c2245e4e-f9d7-4819-a36e-32d0e725327f" />
