### PR TITLE
[Bugfix]: LA-137 fix test case

### DIFF
--- a/test/__test__/signUpCompany.test.ts
+++ b/test/__test__/signUpCompany.test.ts
@@ -114,7 +114,7 @@ describe('Sign Up Company and Owner', () => {
     expect(response.body.message).toBe('Company already exists');
   });
 
-  it('should return 500 if owner already has company', async () => {
+  it('should return 403 if owner already has company', async () => {
     const defaultUser = getDefaultUser();
     const { accessToken } = await defaultUser.generateTokens();
 
@@ -126,8 +126,8 @@ describe('Sign Up Company and Owner', () => {
         slug,
       });
 
-    expect(response.status).toBe(500);
-    expect(response.body.message).toBe('Internal Server Error');
+    expect(response.status).toBe(403);
+    expect(response.body.message).toBe('Unauthorized Access');
   });
 
   it('should return 500 if company creation failed (no _id returned)', async () => {

--- a/test/__test__/signUpLearner.test.ts
+++ b/test/__test__/signUpLearner.test.ts
@@ -105,33 +105,6 @@ describe('Sign Up Learner', () => {
     expect(code).toBeNull();
   });
 
-  it('should register learner if user exists with same company but in different role', async () => {
-    await new ResetCodeBuilder()
-      .withEmail(defaultUser.email)
-      .withCode(verifyValue)
-      .withVerifyType(VerifyCodeType.VERIFICATION)
-      .save();
-
-    const response = await request(app).post(apiPath).set('origin', originURL).send({
-      email: defaultUser.email,
-      username: testUsername,
-      firstName: testFirstname,
-      lastName: testLastname,
-      password: testPassword,
-      termsAccepted: true,
-      verifyValue,
-      companyId: defaultCompany._id,
-    });
-
-    expect(response.status).toBe(201);
-    expect(response.body.message).toBe('Successfully signed up!');
-    expect(response.body).toHaveProperty('refreshToken');
-    expect(response.body).toHaveProperty('accessToken');
-
-    const code = await ResetCodeModel.findOne({ email: defaultUser.email });
-    expect(code).toBeNull();
-  });
-
   it('should return 409 conflict error if username already registered', async () => {
     await new ResetCodeBuilder()
       .withEmail(testEmail)


### PR DESCRIPTION
## Change
1. Not allow same email register twice in same company even different role. Remove learner role test case.
2. Signup company will be reject in authGuard if admin already has company. Change error code and message.

## Test
<img width="298" height="117" alt="Screenshot 2025-08-14 at 20 29 14" src="https://github.com/user-attachments/assets/f0df58c8-b1bf-4cf3-88d2-b81b0fe493c4" />
